### PR TITLE
feat: Fix and provide custom image loader

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { IMAGE_LOADER } from '@angular/common';
 
 import { routes } from './app.routes';
 import { addApiUrl } from './shared/interceptors/api-url.interceptor';
@@ -8,8 +9,8 @@ import { authInterceptor } from './shared/interceptors/auth.interceptor';
 import { TruncateLimit } from './shared/directives/truncate.directive';
 import { ImageLoaderConfig } from '@angular/common';
 
-const imageLoader = (config: ImageLoaderConfig) => {
-  return config.loaderParams;
+export const imageLoader = (config: ImageLoaderConfig) => {
+  return config.loaderParams?.['src'];
 }
 
 export const appConfig: ApplicationConfig = {
@@ -18,6 +19,10 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(
       withInterceptors([addApiUrl, authInterceptor]),
     ),
-    { provide: TruncateLimit, useValue: 70 }
+    { provide: TruncateLimit, useValue: 70 },
+    {
+      provide: IMAGE_LOADER,
+      useValue: imageLoader,
+    }
   ],
 };

--- a/src/app/pages/employees/edit-employee.component.spec.ts
+++ b/src/app/pages/employees/edit-employee.component.spec.ts
@@ -5,6 +5,8 @@ import { EditEmployeeComponent } from './edit-employee.component';
 import { Employee } from 'src/app/infrastructure/types/employee';
 import { PermissionsService } from 'src/app/services/permissions.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IMAGE_LOADER } from '@angular/common';
+import { imageLoader } from 'src/app/app.config';
 
 describe('EditEmployeeComponent', () => {
   let component: EditEmployeeComponent;
@@ -42,6 +44,10 @@ describe('EditEmployeeComponent', () => {
         {
           provide: PermissionsService,
           useValue: mockPermissionsService
+        },
+        {
+          provide: IMAGE_LOADER,
+          useValue: imageLoader
         }
       ]
     })
@@ -62,5 +68,10 @@ describe('EditEmployeeComponent', () => {
     expect(component.form.value.email).toBe(mockEmployee.email);
     expect(component.form.value.position).toBe(mockEmployee.position);
     expect(component.form.value.level).toBe(mockEmployee.level);
+  });
+
+  it('should have a custom image loader', () => {
+    const customImageLoader = TestBed.inject(IMAGE_LOADER);
+    expect(customImageLoader).toBe(imageLoader);
   });
 });


### PR DESCRIPTION
The custom image loader was defined but not provided to the application. This would cause `NgOptimizedImage` to fall back to the default loader.

This change:
- Provides the custom image loader to the application.
- Corrects the image loader to return the `src` property.
- Adds a test to verify the image loader is provided.