### PR TITLE
Add unit test coverage for all previously untested source files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@angular/cli": "22.1.0",
         "@angular/compiler-cli": "22.1.0",
         "@types/jasmine": "6.0.0",
+        "istanbul-lib-instrument": "6.0.3",
         "jasmine-core": "6.3.0",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",
@@ -5960,6 +5961,23 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "@angular/cli": "22.1.0",
     "@angular/compiler-cli": "22.1.0",
     "@types/jasmine": "6.0.0",
-    "puppeteer": "25.4.0",
+    "istanbul-lib-instrument": "6.0.3",
     "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",
     "karma-coverage": "2.2.1",
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.2.0",
+    "puppeteer": "25.4.0",
     "typescript": "6.0.3"
   }
 }

--- a/src/app/app.config.spec.ts
+++ b/src/app/app.config.spec.ts
@@ -1,0 +1,39 @@
+import { ImageLoaderConfig } from '@angular/common';
+import { imageLoader } from './app.config';
+
+describe('imageLoader', () => {
+  it('should return the src from loaderParams when present', () => {
+    const config: ImageLoaderConfig = {
+      src: 'original.png',
+      loaderParams: { src: 'custom-src.png' },
+    };
+
+    expect(imageLoader(config)).toBe('custom-src.png');
+  });
+
+  it('should return undefined when loaderParams is absent', () => {
+    const config: ImageLoaderConfig = {
+      src: 'original.png',
+    };
+
+    expect(imageLoader(config)).toBeUndefined();
+  });
+
+  it('should return undefined when loaderParams is empty', () => {
+    const config: ImageLoaderConfig = {
+      src: 'original.png',
+      loaderParams: {},
+    };
+
+    expect(imageLoader(config)).toBeUndefined();
+  });
+
+  it('should return undefined when loaderParams does not contain src', () => {
+    const config: ImageLoaderConfig = {
+      src: 'original.png',
+      loaderParams: { width: 100 as any },
+    };
+
+    expect(imageLoader(config)).toBeUndefined();
+  });
+});

--- a/src/app/pages/employees/create-employee.component.spec.ts
+++ b/src/app/pages/employees/create-employee.component.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CreateEmployeeComponent } from './create-employee.component';
+import { EmployeeService } from 'src/app/services/employee.service';
+
+describe('CreateEmployeeComponent', () => {
+  let component: CreateEmployeeComponent;
+  let fixture: ComponentFixture<CreateEmployeeComponent>;
+
+  const mockEmployeeService = {
+    createEmployee: jasmine.createSpy('createEmployee'),
+  };
+
+  beforeEach(async () => {
+    mockEmployeeService.createEmployee.calls.reset();
+
+    await TestBed.configureTestingModule({
+      imports: [CreateEmployeeComponent, NoopAnimationsModule],
+      providers: [
+        { provide: EmployeeService, useValue: mockEmployeeService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateEmployeeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should start with an invalid form because firstName is required', () => {
+    expect(component.form.valid).toBeFalse();
+    expect(component.form.controls.firstName.hasError('required')).toBeTrue();
+  });
+
+  it('should not call employeeService.createEmployee when the form is invalid', () => {
+    component.submit();
+    expect(mockEmployeeService.createEmployee).not.toHaveBeenCalled();
+  });
+
+  it('should call employeeService.createEmployee with the form value when the form is valid', () => {
+    component.form.setValue({
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane.smith@example.com',
+      position: 'Developer',
+      level: 'Junior',
+    });
+
+    component.submit();
+
+    expect(mockEmployeeService.createEmployee).toHaveBeenCalledWith(component.form.value);
+  });
+
+  it('should update firstName control when the input value changes', () => {
+    const input: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input');
+    input.value = 'Alice';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.form.controls.firstName.value).toBe('Alice');
+  });
+});

--- a/src/app/pages/employees/employee-details.component.spec.ts
+++ b/src/app/pages/employees/employee-details.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IMAGE_LOADER } from '@angular/common';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { EmployeeDetailsComponent } from './employee-details.component';
 import { ProjectService } from 'src/app/services/project.service';
@@ -42,6 +43,7 @@ describe('EmployeeDetailsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [EmployeeDetailsComponent, NoopAnimationsModule],
       providers: [
+        provideRouter([]),
         { provide: ProjectService, useValue: mockProjectService },
         { provide: IMAGE_LOADER, useValue: imageLoader },
       ],

--- a/src/app/pages/employees/employee-details.component.spec.ts
+++ b/src/app/pages/employees/employee-details.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IMAGE_LOADER } from '@angular/common';
+import { of } from 'rxjs';
+import { EmployeeDetailsComponent } from './employee-details.component';
+import { ProjectService } from 'src/app/services/project.service';
+import { Employee } from 'src/app/infrastructure/types/employee';
+import { Project } from 'src/app/infrastructure/types/project';
+import { imageLoader } from 'src/app/app.config';
+
+describe('EmployeeDetailsComponent', () => {
+  let component: EmployeeDetailsComponent;
+  let fixture: ComponentFixture<EmployeeDetailsComponent>;
+
+  const mockEmployee: Employee = {
+    id: 1,
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john.doe@example.com',
+    position: 'Developer',
+    level: 'Senior',
+    isAvailable: true,
+    profilePicture: 'john.png',
+  };
+
+  const mockProjects: Project[] = [
+    { id: 1, name: 'Project A', description: '', image: 'a.png', employees: [1], subProjectIds: [] },
+    { id: 2, name: 'Project B', description: '', image: 'b.png', employees: [1], subProjectIds: [] },
+  ];
+
+  const mockProjectService = {
+    getProjectsByEmployeeId: jasmine.createSpy('getProjectsByEmployeeId').and.returnValue(of(mockProjects)),
+  };
+
+  beforeEach(async () => {
+    mockProjectService.getProjectsByEmployeeId.calls.reset();
+    mockProjectService.getProjectsByEmployeeId.and.returnValue(of(mockProjects));
+
+    await TestBed.configureTestingModule({
+      imports: [EmployeeDetailsComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: IMAGE_LOADER, useValue: imageLoader },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmployeeDetailsComponent);
+    component = fixture.componentInstance;
+    component.employee = mockEmployee;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch the projects for the given employee on init', () => {
+    expect(mockProjectService.getProjectsByEmployeeId).toHaveBeenCalledWith(mockEmployee.id);
+  });
+
+  it('should render the employee details', () => {
+    const text = fixture.debugElement.nativeElement.textContent;
+    expect(text).toContain(mockEmployee.firstName);
+    expect(text).toContain(mockEmployee.lastName);
+    expect(text).toContain(mockEmployee.position);
+  });
+
+  it('should render a project card per project returned by the service', () => {
+    const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
+    expect(cards.length).toBe(mockProjects.length);
+  });
+});

--- a/src/app/pages/employees/employee-details.component.spec.ts
+++ b/src/app/pages/employees/employee-details.component.spec.ts
@@ -30,6 +30,9 @@ describe('EmployeeDetailsComponent', () => {
 
   const mockProjectService = {
     getProjectsByEmployeeId: jasmine.createSpy('getProjectsByEmployeeId').and.returnValue(of(mockProjects)),
+    getProject: jasmine.createSpy('getProject').and.callFake((id: number) =>
+      of(mockProjects.find((project) => project.id === id)),
+    ),
   };
 
   beforeEach(async () => {

--- a/src/app/pages/employees/employee-list.component.spec.ts
+++ b/src/app/pages/employees/employee-list.component.spec.ts
@@ -71,13 +71,12 @@ describe('EmployeeListComponent', () => {
     expect(component.confirmDialog).toBeNull();
   });
 
-  it('should open the confirmation dialog when the delete button is clicked', async () => {
+  it('should invoke showConfirmationDialog when the delete button is clicked', () => {
+    spyOn(component, 'showConfirmationDialog');
     const deleteButton: HTMLButtonElement = fixture.debugElement.nativeElement.querySelector('button');
     deleteButton.click();
-    await fixture.whenStable();
 
-    expect(component.isConfirmationOpen).toBeTrue();
-    expect(component.confirmDialog).toBeTruthy();
+    expect(component.showConfirmationDialog).toHaveBeenCalled();
   });
 
   it('should call showConfirmationDialog directly and set isConfirmationOpen', async () => {

--- a/src/app/pages/employees/employee-list.component.spec.ts
+++ b/src/app/pages/employees/employee-list.component.spec.ts
@@ -37,6 +37,9 @@ describe('EmployeeListComponent', () => {
 
   const mockEmployeeService = {
     getEmployees: jasmine.createSpy('getEmployees').and.returnValue(of(mockEmployees)),
+    getEmployee: jasmine.createSpy('getEmployee').and.callFake((id: number) =>
+      of(mockEmployees.find((employee) => employee.id === id)),
+    ),
   };
 
   beforeEach(async () => {

--- a/src/app/pages/employees/employee-list.component.spec.ts
+++ b/src/app/pages/employees/employee-list.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IMAGE_LOADER } from '@angular/common';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { EmployeeListComponent } from './employee-list.component';
+import { EmployeeService } from 'src/app/services/employee.service';
+import { Employee } from 'src/app/infrastructure/types/employee';
+import { imageLoader } from 'src/app/app.config';
+
+describe('EmployeeListComponent', () => {
+  let component: EmployeeListComponent;
+  let fixture: ComponentFixture<EmployeeListComponent>;
+
+  const mockEmployees: Employee[] = [
+    {
+      id: 1,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john.doe@example.com',
+      position: 'Developer',
+      level: 'Senior',
+      isAvailable: true,
+      profilePicture: 'john.png',
+    },
+    {
+      id: 2,
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane.smith@example.com',
+      position: 'Designer',
+      level: 'Junior',
+      isAvailable: false,
+      profilePicture: 'jane.png',
+    },
+  ];
+
+  const mockEmployeeService = {
+    getEmployees: jasmine.createSpy('getEmployees').and.returnValue(of(mockEmployees)),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmployeeListComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        { provide: EmployeeService, useValue: mockEmployeeService },
+        { provide: IMAGE_LOADER, useValue: imageLoader },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmployeeListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render a row per employee returned by the service', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(mockEmployees.length);
+  });
+
+  it('should not show the confirmation dialog initially', () => {
+    expect(component.isConfirmationOpen).toBeFalse();
+    expect(component.confirmDialog).toBeNull();
+  });
+
+  it('should open the confirmation dialog when the delete button is clicked', async () => {
+    const deleteButton: HTMLButtonElement = fixture.debugElement.nativeElement.querySelector('button');
+    deleteButton.click();
+    await fixture.whenStable();
+
+    expect(component.isConfirmationOpen).toBeTrue();
+    expect(component.confirmDialog).toBeTruthy();
+  });
+
+  it('should call showConfirmationDialog directly and set isConfirmationOpen', async () => {
+    await component.showConfirmationDialog();
+
+    expect(component.isConfirmationOpen).toBeTrue();
+    expect(component.confirmDialog).toBeTruthy();
+  });
+});

--- a/src/app/pages/login.component.spec.ts
+++ b/src/app/pages/login.component.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../services/auth.service';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  const mockAuthService = {
+    login: jasmine.createSpy('login').and.returnValue(of({ token: 'abc' })),
+  };
+
+  beforeEach(async () => {
+    mockAuthService.login.calls.reset();
+    mockAuthService.login.and.returnValue(of({ token: 'abc' }));
+
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent, NoopAnimationsModule],
+    })
+      .overrideComponent(LoginComponent, {
+        set: { providers: [{ provide: AuthService, useValue: mockAuthService }] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show a warning when email or password is missing', () => {
+    const warning = fixture.debugElement.nativeElement.querySelector('.warning');
+    expect(warning).toBeTruthy();
+  });
+
+  it('should not call authService.login when fields are empty', () => {
+    component.submit();
+    expect(mockAuthService.login).not.toHaveBeenCalled();
+  });
+
+  it('should not call authService.login when only email is filled', () => {
+    component.credentials.email = 'user@example.com';
+    component.submit();
+    expect(mockAuthService.login).not.toHaveBeenCalled();
+  });
+
+  it('should call authService.login with credentials when both fields are filled', () => {
+    component.credentials = { email: 'user@example.com', password: 'secret' };
+    component.submit();
+    expect(mockAuthService.login).toHaveBeenCalledWith(component.credentials);
+  });
+
+  it('should hide the warning once both fields are filled', () => {
+    component.credentials = { email: 'user@example.com', password: 'secret' };
+    fixture.detectChanges();
+    const warning = fixture.debugElement.nativeElement.querySelector('.warning');
+    expect(warning).toBeFalsy();
+  });
+
+  it('should update credentials when the inputs change', () => {
+    const emailInput: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input[name="email"]');
+    const passwordInput: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input[name="password"]');
+
+    emailInput.value = 'typed@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'typedPassword';
+    passwordInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.credentials.email).toBe('typed@example.com');
+    expect(component.credentials.password).toBe('typedPassword');
+  });
+});

--- a/src/app/pages/recruitment/candidate-details.component.spec.ts
+++ b/src/app/pages/recruitment/candidate-details.component.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import { CandidateDetailsComponent } from './candidate-details.component';
+import { Candidate } from 'src/app/infrastructure/types/candidate';
+import { CvEvaluationComponent } from './components/cv-evaluation.component';
+import { InterviewPreparationComponent } from './components/interview-preparation.component';
+import { InterviewFeedbackComponent } from './components/interview-feedback.component';
+import { RejectionLetterComponent } from './components/rejection-letter.component';
+import { OnboardingPreparationComponent } from './components/onboarding-preparation.component';
+import { CandidateFinalizationComponent } from './components/candidate-finalization.component';
+
+describe('CandidateDetailsComponent', () => {
+  let component: CandidateDetailsComponent;
+  let fixture: ComponentFixture<CandidateDetailsComponent>;
+
+  const buildCandidate = (overrides: Partial<Candidate> = {}): Candidate => ({
+    id: 1,
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane.doe@example.com',
+    position: 'Developer',
+    level: 'Senior',
+    status: 'CV evaluation',
+    offerAccepted: false,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CandidateDetailsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CandidateDetailsComponent);
+    component = fixture.componentInstance;
+  });
+
+  const setCandidate = (candidate: Candidate, previous?: Candidate) => {
+    component.candidate = candidate;
+    component.ngOnChanges({
+      candidate: new SimpleChange(previous ?? null, candidate, previous === undefined),
+    });
+    fixture.detectChanges();
+  };
+
+  it('should create', () => {
+    setCandidate(buildCandidate());
+    expect(component).toBeTruthy();
+  });
+
+  it('should render candidate name, email and position', () => {
+    setCandidate(buildCandidate());
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h2')?.textContent).toContain('Jane Doe');
+    expect(compiled.textContent).toContain('Email: jane.doe@example.com');
+    expect(compiled.textContent).toContain('Developer');
+  });
+
+  it('should select CvEvaluationComponent for CV evaluation status', () => {
+    setCandidate(buildCandidate({ status: 'CV evaluation' }));
+    expect(component.actionsSection).toBe(CvEvaluationComponent);
+  });
+
+  it('should select InterviewPreparationComponent for Interview preparation status', () => {
+    setCandidate(buildCandidate({ status: 'Interview preparation' }));
+    expect(component.actionsSection).toBe(InterviewPreparationComponent);
+  });
+
+  it('should select InterviewFeedbackComponent for Interview Feedback status', () => {
+    setCandidate(buildCandidate({ status: 'Interview Feedback' }));
+    expect(component.actionsSection).toBe(InterviewFeedbackComponent);
+  });
+
+  it('should select RejectionLetterComponent for Rejected status', () => {
+    setCandidate(buildCandidate({ status: 'Rejected' }));
+    expect(component.actionsSection).toBe(RejectionLetterComponent);
+  });
+
+  it('should select OnboardingPreparationComponent for Approved status with accepted offer', () => {
+    setCandidate(buildCandidate({ status: 'Approved', offerAccepted: true }));
+    expect(component.actionsSection).toBe(OnboardingPreparationComponent);
+  });
+
+  it('should select CandidateFinalizationComponent for Approved status with pending offer', () => {
+    setCandidate(buildCandidate({ status: 'Approved', offerAccepted: false }));
+    expect(component.actionsSection).toBe(CandidateFinalizationComponent);
+  });
+
+  it('should throw for an unknown status', () => {
+    component.candidate = buildCandidate({ status: 'Unknown' });
+    expect(() =>
+      component.ngOnChanges({
+        candidate: new SimpleChange(null, component.candidate, true),
+      })
+    ).toThrowError('Unknown candidate status: Unknown');
+  });
+
+  it('should not recompute the actions section when candidate input is unchanged', () => {
+    setCandidate(buildCandidate({ status: 'CV evaluation' }));
+    component.actionsSection = null;
+    component.ngOnChanges({});
+    expect(component.actionsSection).toBeNull();
+  });
+
+  it('should render the resolved actions component with the candidateId input', () => {
+    setCandidate(buildCandidate({ status: 'Rejected', id: 42 }));
+    const rejectionEl = fixture.nativeElement.querySelector('app-rejection-letter');
+    expect(rejectionEl).toBeTruthy();
+    expect(rejectionEl.textContent).toContain('Rejection letter');
+  });
+});

--- a/src/app/pages/recruitment/candidates-list.component.spec.ts
+++ b/src/app/pages/recruitment/candidates-list.component.spec.ts
@@ -79,6 +79,7 @@ describe('CandidatesListComponent', () => {
     component.searchControl.setValue('John');
     tick(500);
     fixture.detectChanges();
+    fixture.detectChanges();
 
     expect(mockCandidateService.getCandidatesByName).toHaveBeenCalledWith('John');
     const rows = fixture.nativeElement.querySelectorAll('tbody tr');

--- a/src/app/pages/recruitment/candidates-list.component.spec.ts
+++ b/src/app/pages/recruitment/candidates-list.component.spec.ts
@@ -1,0 +1,112 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { CandidatesListComponent } from './candidates-list.component';
+import { CandidateService } from 'src/app/services/candidate.service';
+import { Candidate } from 'src/app/infrastructure/types/candidate';
+
+describe('CandidatesListComponent', () => {
+  let component: CandidatesListComponent;
+  let fixture: ComponentFixture<CandidatesListComponent>;
+  let mockCandidateService: {
+    getCandidates: jasmine.Spy;
+    getCandidatesByName: jasmine.Spy;
+  };
+
+  const mockCandidates: Candidate[] = [
+    {
+      id: 1,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane.doe@example.com',
+      position: 'Developer',
+      level: 'Senior',
+      status: 'CV evaluation',
+      offerAccepted: false,
+    },
+    {
+      id: 2,
+      firstName: 'John',
+      lastName: 'Smith',
+      email: 'john.smith@example.com',
+      position: 'Designer',
+      level: 'Junior',
+      status: 'Rejected',
+      offerAccepted: false,
+    },
+  ];
+
+  const filteredCandidates: Candidate[] = [mockCandidates[1]];
+
+  beforeEach(async () => {
+    mockCandidateService = {
+      getCandidates: jasmine.createSpy('getCandidates').and.returnValue(of(mockCandidates)),
+      getCandidatesByName: jasmine.createSpy('getCandidatesByName').and.returnValue(of(filteredCandidates)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CandidatesListComponent],
+      providers: [
+        provideRouter([]),
+        { provide: CandidateService, useValue: mockCandidateService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CandidatesListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load all candidates on init', () => {
+    expect(mockCandidateService.getCandidates).toHaveBeenCalled();
+    const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('Jane Doe');
+    expect(rows[0].textContent).toContain('jane.doe@example.com');
+    expect(rows[0].textContent).toContain('Developer');
+  });
+
+  it('should render a routerLink to the candidate details for each row', () => {
+    const link = fixture.nativeElement.querySelector('tbody tr a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/1');
+  });
+
+  it('should search candidates by name after debounce and update the list', fakeAsync(() => {
+    component.searchControl.setValue('John');
+    tick(500);
+    fixture.detectChanges();
+
+    expect(mockCandidateService.getCandidatesByName).toHaveBeenCalledWith('John');
+    const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('John Smith');
+  }));
+
+  it('should reload all candidates when the search value is cleared', fakeAsync(() => {
+    component.searchControl.setValue('John');
+    tick(500);
+    fixture.detectChanges();
+
+    mockCandidateService.getCandidates.calls.reset();
+    component.searchControl.setValue('');
+    tick(500);
+    fixture.detectChanges();
+
+    expect(mockCandidateService.getCandidates).toHaveBeenCalled();
+    const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+  }));
+
+  it('should update the search input value when the user types', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('caption input');
+    input.value = 'Jane';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.searchControl.value).toBe('Jane');
+  });
+});

--- a/src/app/pages/recruitment/candidates-list.component.spec.ts
+++ b/src/app/pages/recruitment/candidates-list.component.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { CandidatesListComponent } from './candidates-list.component';
 import { CandidateService } from 'src/app/services/candidate.service';
 import { Candidate } from 'src/app/infrastructure/types/candidate';
+import { flushChanges } from 'src/testing/flush-changes';
 
 describe('CandidatesListComponent', () => {
   let component: CandidatesListComponent;
@@ -78,8 +79,7 @@ describe('CandidatesListComponent', () => {
   it('should search candidates by name after debounce and update the list', fakeAsync(() => {
     component.searchControl.setValue('John');
     tick(500);
-    fixture.detectChanges();
-    fixture.detectChanges();
+    flushChanges(fixture);
 
     expect(mockCandidateService.getCandidatesByName).toHaveBeenCalledWith('John');
     const rows = fixture.nativeElement.querySelectorAll('tbody tr');
@@ -95,7 +95,7 @@ describe('CandidatesListComponent', () => {
     mockCandidateService.getCandidates.calls.reset();
     component.searchControl.setValue('');
     tick(500);
-    fixture.detectChanges();
+    flushChanges(fixture);
 
     expect(mockCandidateService.getCandidates).toHaveBeenCalled();
     const rows = fixture.nativeElement.querySelectorAll('tbody tr');

--- a/src/app/pages/recruitment/components/candidate-finalization.component.spec.ts
+++ b/src/app/pages/recruitment/components/candidate-finalization.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CandidateFinalizationComponent } from './candidate-finalization.component';
+
+describe('CandidateFinalizationComponent', () => {
+  let component: CandidateFinalizationComponent;
+  let fixture: ComponentFixture<CandidateFinalizationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CandidateFinalizationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CandidateFinalizationComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 1;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(1);
+  });
+
+  it('should render the finalization text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Candidate finalization');
+  });
+});

--- a/src/app/pages/recruitment/components/cv-evaluation.component.spec.ts
+++ b/src/app/pages/recruitment/components/cv-evaluation.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CvEvaluationComponent } from './cv-evaluation.component';
+
+describe('CvEvaluationComponent', () => {
+  let component: CvEvaluationComponent;
+  let fixture: ComponentFixture<CvEvaluationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CvEvaluationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CvEvaluationComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 2;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(2);
+  });
+
+  it('should render the CV evaluation text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('CV evaluation');
+  });
+});

--- a/src/app/pages/recruitment/components/interview-feedback.component.spec.ts
+++ b/src/app/pages/recruitment/components/interview-feedback.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InterviewFeedbackComponent } from './interview-feedback.component';
+
+describe('InterviewFeedbackComponent', () => {
+  let component: InterviewFeedbackComponent;
+  let fixture: ComponentFixture<InterviewFeedbackComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InterviewFeedbackComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterviewFeedbackComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 3;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(3);
+  });
+
+  it('should render the interview feedback text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Interview feedback');
+  });
+});

--- a/src/app/pages/recruitment/components/interview-preparation.component.spec.ts
+++ b/src/app/pages/recruitment/components/interview-preparation.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InterviewPreparationComponent } from './interview-preparation.component';
+
+describe('InterviewPreparationComponent', () => {
+  let component: InterviewPreparationComponent;
+  let fixture: ComponentFixture<InterviewPreparationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InterviewPreparationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterviewPreparationComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 4;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(4);
+  });
+
+  it('should render the interview preparation text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Interview preparation');
+  });
+});

--- a/src/app/pages/recruitment/components/onboarding-preparation.component.spec.ts
+++ b/src/app/pages/recruitment/components/onboarding-preparation.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OnboardingPreparationComponent } from './onboarding-preparation.component';
+
+describe('OnboardingPreparationComponent', () => {
+  let component: OnboardingPreparationComponent;
+  let fixture: ComponentFixture<OnboardingPreparationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OnboardingPreparationComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OnboardingPreparationComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 5;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(5);
+  });
+
+  it('should render the onboarding preparation text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Onboarding preparation');
+  });
+});

--- a/src/app/pages/recruitment/components/rejection-letter.component.spec.ts
+++ b/src/app/pages/recruitment/components/rejection-letter.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RejectionLetterComponent } from './rejection-letter.component';
+
+describe('RejectionLetterComponent', () => {
+  let component: RejectionLetterComponent;
+  let fixture: ComponentFixture<RejectionLetterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RejectionLetterComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RejectionLetterComponent);
+    component = fixture.componentInstance;
+    component.candidateId = 6;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept a candidateId input', () => {
+    expect(component.candidateId).toBe(6);
+  });
+
+  it('should render the rejection letter text', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Rejection letter');
+  });
+});

--- a/src/app/pages/registration.component.spec.ts
+++ b/src/app/pages/registration.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RegistrationComponent } from './registration.component';
+
+describe('RegistrationComponent', () => {
+  let component: RegistrationComponent;
+  let fixture: ComponentFixture<RegistrationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegistrationComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RegistrationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not report a mismatch when confirmPassword is empty', () => {
+    component.credentials = { email: '', password: 'secret', confirmPassword: '' };
+    expect(component.passwordMismatch).toBeFalse();
+  });
+
+  it('should report a mismatch when passwords differ', () => {
+    component.credentials = { email: '', password: 'secret', confirmPassword: 'different' };
+    expect(component.passwordMismatch).toBeTrue();
+  });
+
+  it('should not report a mismatch when passwords match', () => {
+    component.credentials = { email: '', password: 'secret', confirmPassword: 'secret' };
+    expect(component.passwordMismatch).toBeFalse();
+  });
+
+  it('should show an error message in the template when passwords mismatch', () => {
+    component.credentials = { email: 'a@b.com', password: 'secret', confirmPassword: 'different' };
+    fixture.detectChanges();
+    const error = fixture.debugElement.nativeElement.querySelector('.error');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Passwords do not match');
+  });
+
+  it('should not show an error message when passwords match', () => {
+    component.credentials = { email: 'a@b.com', password: 'secret', confirmPassword: 'secret' };
+    fixture.detectChanges();
+    const error = fixture.debugElement.nativeElement.querySelector('.error');
+    expect(error).toBeFalsy();
+  });
+
+  it('should not throw when submit is called with valid matching credentials', () => {
+    component.credentials = { email: 'a@b.com', password: 'secret', confirmPassword: 'secret' };
+    expect(() => component.submit()).not.toThrow();
+  });
+
+  it('should update credentials when the inputs change', () => {
+    const emailInput: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input[name="email"]');
+    const passwordInput: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input[name="password"]');
+    const confirmInput: HTMLInputElement = fixture.debugElement.nativeElement.querySelector('input[name="confirmPassword"]');
+
+    emailInput.value = 'typed@example.com';
+    emailInput.dispatchEvent(new Event('input'));
+    passwordInput.value = 'typedPassword';
+    passwordInput.dispatchEvent(new Event('input'));
+    confirmInput.value = 'typedPassword';
+    confirmInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.credentials.email).toBe('typed@example.com');
+    expect(component.credentials.password).toBe('typedPassword');
+    expect(component.credentials.confirmPassword).toBe('typedPassword');
+  });
+});

--- a/src/app/pages/work/project-details.component.spec.ts
+++ b/src/app/pages/work/project-details.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IMAGE_LOADER } from '@angular/common';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { ProjectDetailsComponent } from './project-details.component';
 import { ProjectService } from 'src/app/services/project.service';
@@ -32,6 +33,7 @@ describe('ProjectDetailsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [ProjectDetailsComponent, NoopAnimationsModule],
       providers: [
+        provideRouter([]),
         { provide: ProjectService, useValue: mockProjectService },
         { provide: IMAGE_LOADER, useValue: imageLoader },
       ],
@@ -69,7 +71,7 @@ describe('ProjectDetailsComponent', () => {
   });
 
   it('should render project details once resolved', () => {
-    component.id = 1;
+    fixture.componentRef.setInput('id', 1);
     fixture.detectChanges();
 
     const text = fixture.debugElement.nativeElement.textContent;
@@ -79,7 +81,7 @@ describe('ProjectDetailsComponent', () => {
   });
 
   it('should render a project card for each subproject', () => {
-    component.id = 1;
+    fixture.componentRef.setInput('id', 1);
     fixture.detectChanges();
 
     const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
@@ -88,7 +90,7 @@ describe('ProjectDetailsComponent', () => {
 
   it('should render no subproject cards when subProjectIds is empty', () => {
     mockProjectService.getProject.and.returnValue(of({ ...mockProject, subProjectIds: [] }));
-    component.id = 1;
+    fixture.componentRef.setInput('id', 1);
     fixture.detectChanges();
 
     const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');

--- a/src/app/pages/work/project-details.component.spec.ts
+++ b/src/app/pages/work/project-details.component.spec.ts
@@ -1,0 +1,97 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IMAGE_LOADER } from '@angular/common';
+import { of } from 'rxjs';
+import { ProjectDetailsComponent } from './project-details.component';
+import { ProjectService } from 'src/app/services/project.service';
+import { Project } from 'src/app/infrastructure/types/project';
+import { imageLoader } from 'src/app/app.config';
+
+describe('ProjectDetailsComponent', () => {
+  let component: ProjectDetailsComponent;
+  let fixture: ComponentFixture<ProjectDetailsComponent>;
+
+  const mockProject: Project = {
+    id: 1,
+    name: 'Project One',
+    description: 'First project',
+    image: 'one.png',
+    employees: [1, 2],
+    subProjectIds: [2, 3],
+  };
+
+  const mockProjectService = {
+    getProject: jasmine.createSpy('getProject').and.returnValue(of(mockProject)),
+    getProjects: jasmine.createSpy('getProjects').and.returnValue(of([mockProject])),
+  };
+
+  beforeEach(async () => {
+    mockProjectService.getProject.calls.reset();
+    mockProjectService.getProject.and.returnValue(of(mockProject));
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectDetailsComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: IMAGE_LOADER, useValue: imageLoader },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectDetailsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    component.id = 1;
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch the project via ProjectService when id input changes', () => {
+    component.id = 1;
+    component.ngOnChanges({
+      id: {
+        currentValue: 1,
+        previousValue: undefined,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+    });
+
+    expect(mockProjectService.getProject).toHaveBeenCalledWith(1);
+  });
+
+  it('should not fetch the project if the id input did not change', () => {
+    component.id = 1;
+    component.ngOnChanges({});
+
+    expect(mockProjectService.getProject).not.toHaveBeenCalled();
+  });
+
+  it('should render project details once resolved', () => {
+    component.id = 1;
+    fixture.detectChanges();
+
+    const text = fixture.debugElement.nativeElement.textContent;
+    expect(text).toContain('Project One');
+    expect(text).toContain('First project');
+    expect(text).toContain('one.png');
+  });
+
+  it('should render a project card for each subproject', () => {
+    component.id = 1;
+    fixture.detectChanges();
+
+    const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
+    expect(cards.length).toBe(2);
+  });
+
+  it('should render no subproject cards when subProjectIds is empty', () => {
+    mockProjectService.getProject.and.returnValue(of({ ...mockProject, subProjectIds: [] }));
+    component.id = 1;
+    fixture.detectChanges();
+
+    const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
+    expect(cards.length).toBe(0);
+  });
+});

--- a/src/app/pages/work/project-list.component.spec.ts
+++ b/src/app/pages/work/project-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IMAGE_LOADER } from '@angular/common';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { ProjectListComponent } from './project-list.component';
 import { ProjectService } from 'src/app/services/project.service';
@@ -42,6 +43,7 @@ describe('ProjectListComponent', () => {
     await TestBed.configureTestingModule({
       imports: [ProjectListComponent, NoopAnimationsModule],
       providers: [
+        provideRouter([]),
         { provide: ProjectService, useValue: mockProjectService },
         { provide: IMAGE_LOADER, useValue: imageLoader },
       ],

--- a/src/app/pages/work/project-list.component.spec.ts
+++ b/src/app/pages/work/project-list.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IMAGE_LOADER } from '@angular/common';
+import { of } from 'rxjs';
+import { ProjectListComponent } from './project-list.component';
+import { ProjectService } from 'src/app/services/project.service';
+import { Project } from 'src/app/infrastructure/types/project';
+import { imageLoader } from 'src/app/app.config';
+
+describe('ProjectListComponent', () => {
+  let component: ProjectListComponent;
+  let fixture: ComponentFixture<ProjectListComponent>;
+
+  const mockProjects: Project[] = [
+    {
+      id: 1,
+      name: 'Project One',
+      description: 'First project',
+      image: 'one.png',
+      employees: [1, 2],
+      subProjectIds: [],
+    },
+    {
+      id: 2,
+      name: 'Project Two',
+      description: 'Second project',
+      image: 'two.png',
+      employees: [3],
+      subProjectIds: [],
+    },
+  ];
+
+  const mockProjectService = {
+    getProjects: jasmine.createSpy('getProjects').and.returnValue(of(mockProjects)),
+    getProject: jasmine.createSpy('getProject').and.returnValue(of(mockProjects[0])),
+  };
+
+  beforeEach(async () => {
+    mockProjectService.getProjects.calls.reset();
+    mockProjectService.getProjects.and.returnValue(of(mockProjects));
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectListComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: IMAGE_LOADER, useValue: imageLoader },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should fetch projects from the ProjectService on construction', () => {
+    expect(mockProjectService.getProjects).toHaveBeenCalled();
+  });
+
+  it('should render a project card for each project', () => {
+    fixture.detectChanges();
+    const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
+    expect(cards.length).toBe(2);
+  });
+
+  it('should render no project cards when there are no projects', () => {
+    mockProjectService.getProjects.and.returnValue(of([]));
+    fixture = TestBed.createComponent(ProjectListComponent);
+    fixture.detectChanges();
+    const cards = fixture.debugElement.nativeElement.querySelectorAll('app-project-card');
+    expect(cards.length).toBe(0);
+  });
+});

--- a/src/app/pages/work/time-off-management.component.spec.ts
+++ b/src/app/pages/work/time-off-management.component.spec.ts
@@ -1,0 +1,139 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { signal } from '@angular/core';
+import { TimeOffManagementComponent } from './time-off-management.component';
+import { TimeOffManagementService } from 'src/app/services/time-off-management.service';
+import { TimeOffRequest } from 'src/app/infrastructure/types/time-off-request.type';
+
+describe('TimeOffManagementComponent', () => {
+  let component: TimeOffManagementComponent;
+  let fixture: ComponentFixture<TimeOffManagementComponent>;
+
+  const mockRequests: TimeOffRequest[] = [
+    {
+      id: 1,
+      employeeId: 10,
+      startDate: '2026-01-01',
+      endDate: '2026-01-05',
+      type: 'Vacation',
+      status: 'Pending',
+      comment: 'Trip',
+    },
+    {
+      id: 2,
+      employeeId: 11,
+      startDate: '2026-02-01',
+      endDate: '2026-02-02',
+      type: 'Sick Leave',
+      status: 'Approved',
+      comment: '',
+    },
+  ];
+
+  let requestsSignal: ReturnType<typeof signal<TimeOffRequest[]>>;
+  let selectedTypeSignal: ReturnType<typeof signal<string>>;
+  let mockTimeOffsService: {
+    requests: ReturnType<typeof signal<TimeOffRequest[]>>;
+    resolvedRequests: () => TimeOffRequest[];
+    selectedType: ReturnType<typeof signal<string>>;
+    approveRequest: jasmine.Spy;
+    rejectRequest: jasmine.Spy;
+    deleteRequest: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    requestsSignal = signal<TimeOffRequest[]>(mockRequests);
+    selectedTypeSignal = signal<string>('');
+    mockTimeOffsService = {
+      requests: requestsSignal,
+      resolvedRequests: () => requestsSignal().filter((r) => r.status !== 'Pending'),
+      selectedType: selectedTypeSignal,
+      approveRequest: jasmine.createSpy('approveRequest'),
+      rejectRequest: jasmine.createSpy('rejectRequest'),
+      deleteRequest: jasmine.createSpy('deleteRequest'),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TimeOffManagementComponent, NoopAnimationsModule],
+      providers: [
+        { provide: TimeOffManagementService, useValue: mockTimeOffsService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimeOffManagementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display resolved and total counts', () => {
+    const text = fixture.debugElement.nativeElement.textContent;
+    expect(text).toContain('Resolved 1 / 2 Unresolved');
+  });
+
+  it('should render a table row for each request', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+  });
+
+  it('should show Approve and Reject buttons only for pending requests', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    const pendingRow = rows[0] as HTMLElement;
+    const approvedRow = rows[1] as HTMLElement;
+
+    const pendingButtons = Array.from(pendingRow.querySelectorAll('button')).map((b) => b.textContent?.trim());
+    expect(pendingButtons).toContain('Approve');
+    expect(pendingButtons).toContain('Reject');
+    expect(pendingButtons).toContain('Delete');
+
+    const approvedButtons = Array.from(approvedRow.querySelectorAll('button')).map((b) => b.textContent?.trim());
+    expect(approvedButtons).not.toContain('Approve');
+    expect(approvedButtons).not.toContain('Reject');
+    expect(approvedButtons).toContain('Delete');
+  });
+
+  it('should call approveRequest on the service when Approve is clicked', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    const approveButton = Array.from(rows[0].querySelectorAll('button')).find(
+      (b: any) => b.textContent.trim() === 'Approve'
+    ) as HTMLButtonElement;
+
+    approveButton.click();
+
+    expect(mockTimeOffsService.approveRequest).toHaveBeenCalledWith(mockRequests[0]);
+  });
+
+  it('should call rejectRequest on the service when Reject is clicked', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    const rejectButton = Array.from(rows[0].querySelectorAll('button')).find(
+      (b: any) => b.textContent.trim() === 'Reject'
+    ) as HTMLButtonElement;
+
+    rejectButton.click();
+
+    expect(mockTimeOffsService.rejectRequest).toHaveBeenCalledWith(mockRequests[0]);
+  });
+
+  it('should call deleteRequest on the service when Delete is clicked', () => {
+    const rows = fixture.debugElement.nativeElement.querySelectorAll('tbody tr');
+    const deleteButton = Array.from(rows[1].querySelectorAll('button')).find(
+      (b: any) => b.textContent.trim() === 'Delete'
+    ) as HTMLButtonElement;
+
+    deleteButton.click();
+
+    expect(mockTimeOffsService.deleteRequest).toHaveBeenCalledWith(mockRequests[1]);
+  });
+
+  it('should update the selectedType signal when the filter select changes', () => {
+    const select: HTMLSelectElement = fixture.debugElement.nativeElement.querySelector('select');
+    select.value = select.options[1].value;
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(selectedTypeSignal()).toBe('Vacation');
+  });
+});

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should start unauthenticated', () => {
+    expect(service.isAuth$.getValue()).toBe(false);
+  });
+
+  it('should send a login request and store the token on success', () => {
+    const credentials = { email: 'jane@example.com', password: 'secret' };
+
+    service.login(credentials).subscribe();
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(credentials);
+    req.flush({ token: 'abc123' });
+
+    expect(sessionStorage.getItem('token')).toBe('abc123');
+    expect(service.isAuth$.getValue()).toBe(true);
+  });
+
+  it('should send a logout request and clear the token', () => {
+    sessionStorage.setItem('token', 'abc123');
+    service.isAuth$.next(true);
+
+    service.logout().subscribe();
+
+    const req = httpMock.expectOne('/api/auth/logout');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush({});
+
+    expect(sessionStorage.getItem('token')).toBeNull();
+    expect(service.isAuth$.getValue()).toBe(false);
+  });
+
+  it('should read the token from sessionStorage via getToken', () => {
+    expect(service.getToken()).toBeNull();
+
+    sessionStorage.setItem('token', 'xyz789');
+    expect(service.getToken()).toBe('xyz789');
+  });
+
+  it('should set isAuth$ to true on restoreSession if a token exists', () => {
+    sessionStorage.setItem('token', 'xyz789');
+
+    service.restoreSession();
+
+    expect(service.isAuth$.getValue()).toBe(true);
+  });
+
+  it('should not change isAuth$ on restoreSession if no token exists', () => {
+    service.restoreSession();
+
+    expect(service.isAuth$.getValue()).toBe(false);
+  });
+});

--- a/src/app/services/candidate.service.spec.ts
+++ b/src/app/services/candidate.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { CandidateService } from './candidate.service';
+import { Candidate } from '../infrastructure/types/candidate';
+
+describe('CandidateService', () => {
+  let service: CandidateService;
+  let httpMock: HttpTestingController;
+
+  const mockCandidates: Candidate[] = [
+    {
+      id: 1,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane.doe@example.com',
+      position: 'Developer',
+      level: 'Senior',
+      status: 'Interviewing',
+      offerAccepted: false,
+    },
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(CandidateService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch all candidates', () => {
+    service.getCandidates().subscribe((candidates) => {
+      expect(candidates).toEqual(mockCandidates);
+    });
+
+    const req = httpMock.expectOne('/candidates');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockCandidates);
+  });
+
+  it('should fetch candidates by name', () => {
+    service.getCandidatesByName('Jane').subscribe((candidates) => {
+      expect(candidates).toEqual(mockCandidates);
+    });
+
+    const req = httpMock.expectOne('/candidates?firstName_like=Jane');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockCandidates);
+  });
+
+  it('should fetch a single candidate by id', () => {
+    service.getCandidate(1).subscribe((candidate) => {
+      expect(candidate).toEqual(mockCandidates[0]);
+    });
+
+    const req = httpMock.expectOne('/candidates/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockCandidates[0]);
+  });
+});

--- a/src/app/services/employee.service.spec.ts
+++ b/src/app/services/employee.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { EmployeeService } from './employee.service';
+import { Employee } from '../infrastructure/types/employee';
+
+describe('EmployeeService', () => {
+  let service: EmployeeService;
+  let httpMock: HttpTestingController;
+
+  const mockEmployee: Employee = {
+    id: 1,
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john.doe@example.com',
+    position: 'Developer',
+    level: 'Senior',
+    isAvailable: true,
+    profilePicture: '',
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting(), EmployeeService],
+    });
+
+    service = TestBed.inject(EmployeeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch all employees', () => {
+    service.getEmployees().subscribe((employees) => {
+      expect(employees).toEqual([mockEmployee]);
+    });
+
+    const req = httpMock.expectOne('/employees');
+    expect(req.request.method).toBe('GET');
+    req.flush([mockEmployee]);
+  });
+
+  it('should fetch a single employee by id', () => {
+    service.getEmployee(1).subscribe((employee) => {
+      expect(employee).toEqual(mockEmployee);
+    });
+
+    const req = httpMock.expectOne('/employees/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockEmployee);
+  });
+
+  it('should create an employee', () => {
+    const { id, isAvailable, ...newEmployee } = mockEmployee;
+
+    service.createEmployee(newEmployee).subscribe();
+
+    const req = httpMock.expectOne('/employees');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(newEmployee);
+    req.flush(mockEmployee);
+  });
+});

--- a/src/app/services/notification.service.spec.ts
+++ b/src/app/services/notification.service.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { NotificationService } from './notification.service';
+import { SocketService } from './socket.service';
+import { Notification } from '../infrastructure/types/notification';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let notifications$: Subject<Notification[]>;
+
+  const mockNotification: Notification = {
+    id: 1,
+    title: 'New request',
+    message: 'A new time off request was submitted',
+    type: 'TimeOff',
+    read: false,
+    date: '2026-01-01',
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    notifications$ = new Subject<Notification[]>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SocketService,
+          useValue: { notifications$ },
+        },
+      ],
+    });
+
+    service = TestBed.inject(NotificationService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should start with an empty notifications list when localStorage is empty', () => {
+    expect(service.notifications()).toEqual([]);
+  });
+
+  it('should restore notifications from localStorage on construction', () => {
+    localStorage.setItem('notifications', JSON.stringify([mockNotification]));
+
+    const restoredService = TestBed.runInInjectionContext(() => new NotificationService());
+
+    expect(restoredService.notifications()).toEqual([mockNotification]);
+  });
+
+  it('should add a notification', () => {
+    service.addNotification(mockNotification);
+
+    expect(service.notifications()).toEqual([mockNotification]);
+  });
+
+  it('should mark a single notification as read', () => {
+    service.addNotification(mockNotification);
+    service.addNotification({ ...mockNotification, id: 2 });
+
+    service.markAsRead(mockNotification);
+
+    expect(service.notifications()).toEqual([
+      { ...mockNotification, read: true },
+      { ...mockNotification, id: 2, read: false },
+    ]);
+  });
+
+  it('should mark all notifications as read', () => {
+    service.addNotification(mockNotification);
+    service.addNotification({ ...mockNotification, id: 2 });
+
+    service.markAllAsRead();
+
+    expect(service.notifications().every((n) => n.read)).toBe(true);
+  });
+
+  it('should compute readNotifications and unreadNotifications', () => {
+    service.addNotification({ ...mockNotification, id: 1, read: true });
+    service.addNotification({ ...mockNotification, id: 2, read: false });
+
+    expect(service.readNotifications()).toEqual([{ ...mockNotification, id: 1, read: true }]);
+    expect(service.unreadNotifications()).toEqual([{ ...mockNotification, id: 2, read: false }]);
+  });
+
+  it('should replace notifications when the socket emits', () => {
+    TestBed.runInInjectionContext(() => service.connect());
+
+    notifications$.next([mockNotification]);
+
+    expect(service.notifications()).toEqual([mockNotification]);
+  });
+
+  it('should persist notifications to localStorage via the effect', () => {
+    service.addNotification(mockNotification);
+
+    TestBed.tick();
+
+    expect(JSON.parse(localStorage.getItem('notifications') ?? '[]')).toEqual([mockNotification]);
+  });
+});

--- a/src/app/services/permissions.service.spec.ts
+++ b/src/app/services/permissions.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { PermissionsService } from './permissions.service';
+
+describe('PermissionsService', () => {
+  let service: PermissionsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PermissionsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should emit false for permissions that have not been set', (done) => {
+    service.hasPermission('ViewEmployees').subscribe((value) => {
+      expect(value).toBe(false);
+      done();
+    });
+  });
+
+  it('should emit true after a permission is set', (done) => {
+    service.setPermissions({ ViewEmployees: true });
+
+    service.hasPermission('ViewEmployees').subscribe((value) => {
+      expect(value).toBe(true);
+      done();
+    });
+  });
+
+  it('should merge new permissions with existing ones', (done) => {
+    service.setPermissions({ ViewEmployees: true });
+    service.setPermissions({ CreateEmployee: true });
+
+    service.hasPermissions(['ViewEmployees', 'CreateEmployee']).subscribe((value) => {
+      expect(value).toBe(true);
+      done();
+    });
+  });
+
+  it('should return false from hasPermissions if any permission is missing', (done) => {
+    service.setPermissions({ ViewEmployees: true });
+
+    service.hasPermissions(['ViewEmployees', 'CreateEmployee']).subscribe((value) => {
+      expect(value).toBe(false);
+      done();
+    });
+  });
+
+  it('should revoke a permission', (done) => {
+    service.setPermissions({ ViewEmployees: true });
+    service.revokePermission('ViewEmployees');
+
+    service.hasPermission('ViewEmployees').subscribe((value) => {
+      expect(value).toBe(false);
+      done();
+    });
+  });
+
+  it('should not affect other permissions when revoking one', (done) => {
+    service.setPermissions({ ViewEmployees: true, CreateEmployee: true });
+    service.revokePermission('ViewEmployees');
+
+    service.hasPermission('CreateEmployee').subscribe((value) => {
+      expect(value).toBe(true);
+      done();
+    });
+  });
+});

--- a/src/app/services/project.service.spec.ts
+++ b/src/app/services/project.service.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ProjectService } from './project.service';
+import { Project } from '../infrastructure/types/project';
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+  let httpMock: HttpTestingController;
+
+  const mockProject: Project = {
+    id: 1,
+    name: 'HRMS',
+    description: 'HR Management System',
+    image: '',
+    employees: [1, 2],
+    subProjectIds: [],
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(ProjectService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch a single project by id', () => {
+    service.getProject(1).subscribe((project) => {
+      expect(project).toEqual(mockProject);
+    });
+
+    const req = httpMock.expectOne('/projects/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockProject);
+  });
+
+  it('should fetch all projects', () => {
+    service.getProjects().subscribe((projects) => {
+      expect(projects).toEqual([mockProject]);
+    });
+
+    const req = httpMock.expectOne('/projects');
+    expect(req.request.method).toBe('GET');
+    req.flush([mockProject]);
+  });
+
+  it('should fetch projects by employee id', () => {
+    service.getProjectsByEmployeeId(1).subscribe((projects) => {
+      expect(projects).toEqual([mockProject]);
+    });
+
+    const req = httpMock.expectOne('/projects?employees_like=1');
+    expect(req.request.method).toBe('GET');
+    req.flush([mockProject]);
+  });
+});

--- a/src/app/services/socket.service.spec.ts
+++ b/src/app/services/socket.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { SocketService } from './socket.service';
+
+describe('SocketService', () => {
+  let service: SocketService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SocketService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not emit before the interval elapses', fakeAsync(() => {
+    const emissions: unknown[] = [];
+    const subscription = service.notifications$.subscribe((value) => emissions.push(value));
+
+    tick(2_499);
+    expect(emissions.length).toBe(0);
+
+    subscription.unsubscribe();
+    tick(1);
+  }));
+
+  it('should emit an empty array every 2500ms', fakeAsync(() => {
+    const emissions: unknown[] = [];
+    const subscription = service.notifications$.subscribe((value) => emissions.push(value));
+
+    tick(2_500);
+    expect(emissions.length).toBe(1);
+    expect(emissions[0]).toEqual([]);
+
+    tick(2_500);
+    expect(emissions.length).toBe(2);
+    expect(emissions[1]).toEqual([]);
+
+    subscription.unsubscribe();
+  }));
+});

--- a/src/app/services/time-off-management.service.spec.ts
+++ b/src/app/services/time-off-management.service.spec.ts
@@ -1,0 +1,118 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { TimeOffManagementService } from './time-off-management.service';
+import { TimeOffRequestService } from './time-off-request.service';
+import { TimeOffRequest } from '../infrastructure/types/time-off-request.type';
+
+describe('TimeOffManagementService', () => {
+  let service: TimeOffManagementService;
+  let mockTimeOffRequestService: jasmine.SpyObj<TimeOffRequestService>;
+
+  const mockRequests: TimeOffRequest[] = [
+    {
+      id: 1,
+      employeeId: 1,
+      startDate: '2026-01-01',
+      endDate: '2026-01-05',
+      type: 'Vacation',
+      status: 'Pending',
+    },
+    {
+      id: 2,
+      employeeId: 2,
+      startDate: '2026-02-01',
+      endDate: '2026-02-02',
+      type: 'Sick Leave',
+      status: 'Approved',
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockTimeOffRequestService = jasmine.createSpyObj('TimeOffRequestService', [
+      'getRequestsByType',
+      'approveRequest',
+      'rejectRequest',
+      'deleteRequest',
+    ]);
+    mockTimeOffRequestService.getRequestsByType.and.returnValue(of(mockRequests));
+    mockTimeOffRequestService.approveRequest.and.returnValue(of({}));
+    mockTimeOffRequestService.rejectRequest.and.returnValue(of({}));
+    mockTimeOffRequestService.deleteRequest.and.returnValue(of({}));
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: TimeOffRequestService, useValue: mockTimeOffRequestService }],
+    });
+
+    service = TestBed.inject(TimeOffManagementService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should default selectedType to an empty string when localStorage is empty', () => {
+    expect(service.selectedType()).toBe('');
+  });
+
+  it('should initialize selectedType from localStorage', () => {
+    localStorage.setItem('selectedType', 'Vacation');
+
+    const restoredService = TestBed.runInInjectionContext(() => new TimeOffManagementService());
+
+    expect(restoredService.selectedType()).toBe('Vacation');
+  });
+
+  it('should fetch requests for the current type once the initial effect flushes', () => {
+    TestBed.tick();
+
+    expect(mockTimeOffRequestService.getRequestsByType).toHaveBeenCalledWith('');
+    expect(service.requests()).toEqual(mockRequests);
+  });
+
+  it('should compute resolvedRequests excluding pending requests', () => {
+    TestBed.tick();
+
+    expect(service.resolvedRequests()).toEqual(mockRequests.filter((r) => r.status !== 'Pending'));
+  });
+
+  it('should approve a request and refresh the request list', () => {
+    TestBed.tick();
+    const request = mockRequests[0];
+
+    service.approveRequest(request);
+
+    expect(mockTimeOffRequestService.approveRequest).toHaveBeenCalledWith(request.id);
+    expect(service.requests()).toEqual(mockRequests);
+  });
+
+  it('should reject a request and refresh the request list', () => {
+    TestBed.tick();
+    const request = mockRequests[0];
+
+    service.rejectRequest(request);
+
+    expect(mockTimeOffRequestService.rejectRequest).toHaveBeenCalledWith(request.id);
+  });
+
+  it('should delete a request and refresh the request list', () => {
+    TestBed.tick();
+    const request = mockRequests[0];
+
+    service.deleteRequest(request);
+
+    expect(mockTimeOffRequestService.deleteRequest).toHaveBeenCalledWith(request.id);
+  });
+
+  it('should persist selectedType to localStorage via the effect', () => {
+    service.selectedType.set('Sick Leave');
+
+    TestBed.tick();
+
+    expect(localStorage.getItem('selectedType')).toBe('Sick Leave');
+  });
+});

--- a/src/app/services/time-off-request.service.spec.ts
+++ b/src/app/services/time-off-request.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { TimeOffRequestService } from './time-off-request.service';
+import { TimeOffRequest } from '../infrastructure/types/time-off-request.type';
+
+describe('TimeOffRequestService', () => {
+  let service: TimeOffRequestService;
+  let httpMock: HttpTestingController;
+
+  const mockRequests: TimeOffRequest[] = [
+    {
+      id: 1,
+      employeeId: 1,
+      startDate: '2026-01-01',
+      endDate: '2026-01-05',
+      type: 'Vacation',
+      status: 'Pending',
+    },
+    {
+      id: 2,
+      employeeId: 2,
+      startDate: '2026-02-01',
+      endDate: '2026-02-02',
+      type: 'Sick Leave',
+      status: 'Approved',
+    },
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(TimeOffRequestService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch all requests', () => {
+    service.getRequests().subscribe((requests) => {
+      expect(requests).toEqual(mockRequests);
+    });
+
+    const req = httpMock.expectOne('/time-off-requests');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockRequests);
+  });
+
+  it('should fetch all requests and filter by type on the client', () => {
+    service.getRequestsByType('Vacation').subscribe((requests) => {
+      expect(requests).toEqual([mockRequests[0]]);
+    });
+
+    const req = httpMock.expectOne('/time-off-requests');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockRequests);
+  });
+
+  it('should return all requests when no type filter is provided', () => {
+    service.getRequestsByType().subscribe((requests) => {
+      expect(requests).toEqual(mockRequests);
+    });
+
+    const req = httpMock.expectOne('/time-off-requests');
+    req.flush(mockRequests);
+  });
+
+  it('should reject a request', () => {
+    service.rejectRequest(1).subscribe();
+
+    const req = httpMock.expectOne('/time-off-requests/1');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ status: 'Rejected' });
+    req.flush({});
+  });
+
+  it('should approve a request', () => {
+    service.approveRequest(1).subscribe();
+
+    const req = httpMock.expectOne('/time-off-requests/1');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ status: 'Approved' });
+    req.flush({});
+  });
+
+  it('should delete a request', () => {
+    service.deleteRequest(1).subscribe();
+
+    const req = httpMock.expectOne('/time-off-requests/1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+  });
+});

--- a/src/app/shared/components/confirmation-dialog.component.spec.ts
+++ b/src/app/shared/components/confirmation-dialog.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ConfirmationDialogComponent } from './confirmation-dialog.component';
+
+describe('ConfirmationDialogComponent', () => {
+  let component: ConfirmationDialogComponent;
+  let fixture: ComponentFixture<ConfirmationDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfirmationDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should be open by default', () => {
+    expect(component.isConfirmationOpen).toBeTrue();
+    const dialog: HTMLElement = fixture.debugElement.query(By.css('dialog')).nativeElement;
+    expect(dialog.hasAttribute('open')).toBeTrue();
+  });
+
+  it('should close the dialog when Cancel is clicked', () => {
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const cancelButton: HTMLButtonElement = buttons[0].nativeElement;
+    expect(cancelButton.textContent).toContain('Cancel');
+
+    cancelButton.click();
+    fixture.detectChanges();
+
+    expect(component.isConfirmationOpen).toBeFalse();
+    const dialog: HTMLElement = fixture.debugElement.query(By.css('dialog')).nativeElement;
+    expect(dialog.hasAttribute('open')).toBeFalse();
+  });
+
+  it('should close the dialog when Confirm is clicked', () => {
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const confirmButton: HTMLButtonElement = buttons[1].nativeElement;
+    expect(confirmButton.textContent).toContain('Confirm');
+
+    confirmButton.click();
+    fixture.detectChanges();
+
+    expect(component.isConfirmationOpen).toBeFalse();
+  });
+});

--- a/src/app/shared/components/file-upload.component.spec.ts
+++ b/src/app/shared/components/file-upload.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FileUploadComponent } from './file-upload.component';
+
+function createFile(name: string, type: string): File {
+  return new File(['content'], name, { type });
+}
+
+function createFileList(files: File[]): FileList {
+  const dataTransfer = new DataTransfer();
+  files.forEach(f => dataTransfer.items.add(f));
+  return dataTransfer.files;
+}
+
+describe('FileUploadComponent', () => {
+  let component: FileUploadComponent;
+  let fixture: ComponentFixture<FileUploadComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FileUploadComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileUploadComponent);
+    component = fixture.componentInstance;
+    component.label = 'Upload file';
+    component.accept = ['image/png', 'image/jpeg'];
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the label input', () => {
+    const label: HTMLLabelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+    expect(label.textContent).toContain('Upload file');
+  });
+
+  it('should set the accept attribute from the accept input', () => {
+    const input: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+    expect(input.getAttribute('accept')).toBe('image/png,image/jpeg');
+  });
+
+  it('should transform a comma separated string into an array via the input transform', () => {
+    fixture.componentRef.setInput('accept', 'text/csv,application/pdf');
+    fixture.detectChanges();
+    expect(component.accept).toEqual(['text/csv', 'application/pdf']);
+  });
+
+  it('should emit selected with the FileList when all files are of an accepted type', () => {
+    const emitted: FileList[] = [];
+    component.selected.subscribe(files => emitted.push(files));
+
+    const files = createFileList([createFile('a.png', 'image/png')]);
+    const input: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+    Object.defineProperty(input, 'files', { value: files });
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(emitted.length).toBe(1);
+    expect(emitted[0]).toBe(files);
+    expect(component.errorMessage).toBe('');
+  });
+
+  it('should set an error message and not emit when a file type is not accepted', () => {
+    const emitted: FileList[] = [];
+    component.selected.subscribe(files => emitted.push(files));
+
+    const files = createFileList([createFile('a.txt', 'text/plain')]);
+    const input: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+    Object.defineProperty(input, 'files', { value: files });
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(emitted.length).toBe(0);
+    expect(component.errorMessage).toBe('Invalid file type');
+  });
+
+  it('should render the error message and accepted file types when errorMessage is set', () => {
+    component.errorMessage = 'Invalid file type';
+    fixture.detectChanges();
+
+    const error = fixture.debugElement.query(By.css('.error'));
+    expect(error).toBeTruthy();
+    const items = fixture.debugElement.queryAll(By.css('.error li'));
+    expect(items.length).toBe(2);
+    expect(items[0].nativeElement.textContent).toContain('image/png');
+    expect(items[1].nativeElement.textContent).toContain('image/jpeg');
+  });
+
+  it('should not render the error message when there is none', () => {
+    component.errorMessage = '';
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.error'))).toBeFalsy();
+  });
+});

--- a/src/app/shared/components/file-upload.component.spec.ts
+++ b/src/app/shared/components/file-upload.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { FileUploadComponent } from './file-upload.component';
+import { flushChanges } from 'src/testing/flush-changes';
 
 function createFile(name: string, type: string): File {
   return new File(['content'], name, { type });
@@ -79,8 +80,7 @@ describe('FileUploadComponent', () => {
 
   it('should render the error message and accepted file types when errorMessage is set', () => {
     component.errorMessage = 'Invalid file type';
-    fixture.detectChanges();
-    fixture.detectChanges();
+    flushChanges(fixture);
 
     const error = fixture.debugElement.query(By.css('.error'));
     expect(error).toBeTruthy();

--- a/src/app/shared/components/file-upload.component.spec.ts
+++ b/src/app/shared/components/file-upload.component.spec.ts
@@ -80,6 +80,7 @@ describe('FileUploadComponent', () => {
   it('should render the error message and accepted file types when errorMessage is set', () => {
     component.errorMessage = 'Invalid file type';
     fixture.detectChanges();
+    fixture.detectChanges();
 
     const error = fixture.debugElement.query(By.css('.error'));
     expect(error).toBeTruthy();

--- a/src/app/shared/components/footer.component.spec.ts
+++ b/src/app/shared/components/footer.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { FooterComponent } from './footer.component';
+import { AuthService } from '../../services/auth.service';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+  let isAuth$: BehaviorSubject<boolean>;
+
+  beforeEach(async () => {
+    isAuth$ = new BehaviorSubject<boolean>(false);
+    const mockAuthService = { isAuth$ };
+
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: mockAuthService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the HRMS heading and social links', () => {
+    const compiled: HTMLElement = fixture.nativeElement;
+    expect(compiled.querySelector('h2')?.textContent).toContain('HRMS');
+    const links = fixture.debugElement.queryAll(By.css('.links a'));
+    expect(links.length).toBe(2);
+  });
+
+  it('should not render legal links when not authenticated', () => {
+    expect(fixture.debugElement.query(By.css('.legal'))).toBeFalsy();
+  });
+
+  it('should render legal links when authenticated', () => {
+    isAuth$.next(true);
+    fixture.detectChanges();
+
+    const legal = fixture.debugElement.query(By.css('.legal'));
+    expect(legal).toBeTruthy();
+    const links = fixture.debugElement.queryAll(By.css('.legal a'));
+    expect(links.length).toBe(3);
+  });
+
+  it('should hide legal links again after logging out', () => {
+    isAuth$.next(true);
+    fixture.detectChanges();
+    isAuth$.next(false);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.legal'))).toBeFalsy();
+  });
+});

--- a/src/app/shared/components/header.component.spec.ts
+++ b/src/app/shared/components/header.component.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { signal } from '@angular/core';
+import { HeaderComponent } from './header.component';
+import { NotificationService } from 'src/app/services/notification.service';
+import { Notification } from 'src/app/infrastructure/types/notification';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let notificationsSignal: ReturnType<typeof signal<Notification[]>>;
+  let unreadNotificationsSignal: ReturnType<typeof signal<Notification[]>>;
+  let mockNotificationService: {
+    notifications: ReturnType<typeof signal<Notification[]>>;
+    unreadNotifications: ReturnType<typeof signal<Notification[]>>;
+    markAsRead: jasmine.Spy;
+    connect: jasmine.Spy;
+  };
+
+  const notifications: Notification[] = [
+    { id: 1, title: 'Time Off', message: 'Approved', type: 'TimeOff', read: false, date: '2026-01-01' },
+    { id: 2, title: 'Birthday', message: 'Happy Birthday', type: 'Birthday', read: true, date: '2026-01-02' },
+  ];
+
+  beforeEach(async () => {
+    notificationsSignal = signal(notifications);
+    unreadNotificationsSignal = signal(notifications.filter(n => !n.read));
+    mockNotificationService = {
+      notifications: notificationsSignal,
+      unreadNotifications: unreadNotificationsSignal,
+      markAsRead: jasmine.createSpy('markAsRead'),
+      connect: jasmine.createSpy('connect'),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HeaderComponent],
+      providers: [
+        { provide: NotificationService, useValue: mockNotificationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should connect to the notification service on construction', () => {
+    expect(mockNotificationService.connect).toHaveBeenCalled();
+  });
+
+  it('should render the count of unread notifications', () => {
+    const button: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    expect(button.textContent).toContain('1');
+  });
+
+  it('should not have the notifications dialog open by default', () => {
+    const dialog: HTMLElement = fixture.debugElement.query(By.css('dialog')).nativeElement;
+    expect(dialog.hasAttribute('open')).toBeFalse();
+  });
+
+  it('should open the notifications dialog when the header button is clicked', () => {
+    const button: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    button.click();
+    fixture.detectChanges();
+
+    const dialog: HTMLElement = fixture.debugElement.query(By.css('dialog')).nativeElement;
+    expect(dialog.hasAttribute('open')).toBeTrue();
+  });
+
+  it('should list all notifications with their title and message', () => {
+    const button: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    button.click();
+    fixture.detectChanges();
+
+    const items = fixture.debugElement.queryAll(By.css('li'));
+    expect(items.length).toBe(2);
+    expect(items[0].query(By.css('h4')).nativeElement.textContent).toContain('Time Off');
+    expect(items[0].query(By.css('span')).nativeElement.textContent).toContain('Approved');
+  });
+
+  it('should only show the "Mark as Read" button for unread notifications', () => {
+    const button: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    button.click();
+    fixture.detectChanges();
+
+    const items = fixture.debugElement.queryAll(By.css('li'));
+    expect(items[0].queryAll(By.css('button')).length).toBe(1);
+    expect(items[1].queryAll(By.css('button')).length).toBe(0);
+  });
+
+  it('should call markNotificationAsRead with the notification when "Mark as Read" is clicked', () => {
+    const headerButton: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    headerButton.click();
+    fixture.detectChanges();
+
+    const markAsReadButton: HTMLButtonElement = fixture.debugElement.query(By.css('li button')).nativeElement;
+    markAsReadButton.click();
+    fixture.detectChanges();
+
+    expect(mockNotificationService.markAsRead).toHaveBeenCalledWith(notifications[0]);
+  });
+
+  it('should close the dialog when the Close button is clicked', () => {
+    const headerButton: HTMLButtonElement = fixture.debugElement.query(By.css('header button')).nativeElement;
+    headerButton.click();
+    fixture.detectChanges();
+
+    const buttons = fixture.debugElement.queryAll(By.css('dialog button'));
+    const closeButton: HTMLButtonElement = buttons[buttons.length - 1].nativeElement;
+    expect(closeButton.textContent).toContain('Close');
+    closeButton.click();
+    fixture.detectChanges();
+
+    const dialog: HTMLElement = fixture.debugElement.query(By.css('dialog')).nativeElement;
+    expect(dialog.hasAttribute('open')).toBeFalse();
+  });
+});

--- a/src/app/shared/components/loader.component.spec.ts
+++ b/src/app/shared/components/loader.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { LoaderComponent } from './loader.component';
+
+describe('LoaderComponent', () => {
+  let component: LoaderComponent;
+  let fixture: ComponentFixture<LoaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should default loading to false and not render the blocker', () => {
+    expect(component.loading).toBeFalse();
+    expect(fixture.debugElement.query(By.css('.blocker'))).toBeFalsy();
+  });
+
+  it('should render the blocker when loading is true', () => {
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.blocker'))).toBeTruthy();
+  });
+
+  it('should project content', () => {
+    const projectedFixture = TestBed.createComponent(LoaderComponent);
+    projectedFixture.nativeElement.innerHTML = '';
+    projectedFixture.detectChanges();
+    const container = projectedFixture.debugElement.query(By.css('.loading-container'));
+    expect(container).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/project-card.component.spec.ts
+++ b/src/app/shared/components/project-card.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { IMAGE_LOADER } from '@angular/common';
+import { of } from 'rxjs';
+import { ProjectCardComponent } from './project-card.component';
+import { ProjectService } from 'src/app/services/project.service';
+import { Project } from 'src/app/infrastructure/types/project';
+import { imageLoader } from 'src/app/app.config';
+
+describe('ProjectCardComponent', () => {
+  let component: ProjectCardComponent;
+  let fixture: ComponentFixture<ProjectCardComponent>;
+  let mockProjectService: { getProject: jasmine.Spy };
+
+  const mockProject: Project = {
+    id: 1,
+    name: 'HRMS Revamp',
+    description: 'Revamp the HRMS platform',
+    image: 'hrms.png',
+    employees: [1, 2],
+    subProjectIds: [],
+  };
+
+  beforeEach(async () => {
+    mockProjectService = {
+      getProject: jasmine.createSpy('getProject').and.returnValue(of(mockProject)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProjectCardComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: IMAGE_LOADER, useValue: imageLoader },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('projectId', 1);
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should not render the card before projectId is set', () => {
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('.card'))).toBeFalsy();
+  });
+
+  it('should fetch the project by id when projectId changes', () => {
+    fixture.componentRef.setInput('projectId', 1);
+    fixture.detectChanges();
+
+    expect(mockProjectService.getProject).toHaveBeenCalledWith(1);
+  });
+
+  it('should render the project name and link once loaded', () => {
+    fixture.componentRef.setInput('projectId', 1);
+    fixture.detectChanges();
+
+    const link = fixture.debugElement.query(By.css('.card-body a'));
+    expect(link.nativeElement.textContent).toContain('HRMS Revamp');
+    expect(link.attributes['href']).toBe('/work/projects/1');
+  });
+
+  it('should re-fetch the project when projectId changes to a new value', () => {
+    fixture.componentRef.setInput('projectId', 1);
+    fixture.detectChanges();
+
+    fixture.componentRef.setInput('projectId', 2);
+    fixture.detectChanges();
+
+    expect(mockProjectService.getProject).toHaveBeenCalledWith(2);
+    expect(mockProjectService.getProject).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/shared/directives/employee-not-available.directive.spec.ts
+++ b/src/app/shared/directives/employee-not-available.directive.spec.ts
@@ -5,6 +5,7 @@ import { of } from 'rxjs';
 import { EmployeeNotAvailableDirective } from './employee-not-available.directive';
 import { EmployeeService } from 'src/app/services/employee.service';
 import { Employee } from 'src/app/infrastructure/types/employee';
+import { flushChanges } from 'src/testing/flush-changes';
 
 const mockEmployee: Employee = {
   id: 1,
@@ -48,7 +49,7 @@ describe('EmployeeNotAvailableDirective', () => {
     const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
     fixture.detectChanges();
     await fixture.whenStable();
-    fixture.detectChanges();
+    flushChanges(fixture);
 
     expect(mockEmployeeService.getEmployee).toHaveBeenCalledWith(1);
     const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
@@ -72,7 +73,7 @@ describe('EmployeeNotAvailableDirective', () => {
     const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
     fixture.detectChanges();
     await fixture.whenStable();
-    fixture.detectChanges();
+    flushChanges(fixture);
 
     const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
     expect(link.classList.contains('not-available')).toBeFalse();

--- a/src/app/shared/directives/employee-not-available.directive.spec.ts
+++ b/src/app/shared/directives/employee-not-available.directive.spec.ts
@@ -1,0 +1,101 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, RouterLink } from '@angular/router';
+import { of } from 'rxjs';
+import { EmployeeNotAvailableDirective } from './employee-not-available.directive';
+import { EmployeeService } from 'src/app/services/employee.service';
+import { Employee } from 'src/app/infrastructure/types/employee';
+
+const mockEmployee: Employee = {
+  id: 1,
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john.doe@example.com',
+  position: 'Developer',
+  level: 'Senior',
+  isAvailable: false,
+  profilePicture: '',
+};
+
+@Component({
+  standalone: true,
+  imports: [RouterLink, EmployeeNotAvailableDirective],
+  template: `<a routerLink="/employees/details/1">John Doe</a>`,
+})
+class HostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [RouterLink, EmployeeNotAvailableDirective],
+  template: `<a routerLink="/employees">Employees</a>`,
+})
+class OtherRouteHostComponent {}
+
+describe('EmployeeNotAvailableDirective', () => {
+  it('should mark the link as not-available and set a tooltip when the employee is unavailable', async () => {
+    const mockEmployeeService = {
+      getEmployee: jasmine.createSpy('getEmployee').and.returnValue(of(mockEmployee)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        provideRouter([]),
+        { provide: EmployeeService, useValue: mockEmployeeService },
+      ],
+    }).compileComponents();
+
+    const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    expect(mockEmployeeService.getEmployee).toHaveBeenCalledWith(1);
+    const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(link.classList.contains('not-available')).toBeTrue();
+    expect(link.getAttribute('title')).toBe('Employee is not available');
+  });
+
+  it('should not mark the link as not-available when the employee is available', async () => {
+    const mockEmployeeService = {
+      getEmployee: jasmine.createSpy('getEmployee').and.returnValue(of({ ...mockEmployee, isAvailable: true })),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        provideRouter([]),
+        { provide: EmployeeService, useValue: mockEmployeeService },
+      ],
+    }).compileComponents();
+
+    const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(link.classList.contains('not-available')).toBeFalse();
+    expect(link.getAttribute('title')).toBe('');
+  });
+
+  it('should not call the employee service when the link does not point to employee details', async () => {
+    const mockEmployeeService = {
+      getEmployee: jasmine.createSpy('getEmployee').and.returnValue(of(mockEmployee)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [OtherRouteHostComponent],
+      providers: [
+        provideRouter([]),
+        { provide: EmployeeService, useValue: mockEmployeeService },
+      ],
+    }).compileComponents();
+
+    const fixture: ComponentFixture<OtherRouteHostComponent> = TestBed.createComponent(OtherRouteHostComponent);
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    expect(mockEmployeeService.getEmployee).not.toHaveBeenCalled();
+    const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(link.classList.contains('not-available')).toBeFalse();
+  });
+});

--- a/src/app/shared/directives/employee-not-available.directive.spec.ts
+++ b/src/app/shared/directives/employee-not-available.directive.spec.ts
@@ -47,6 +47,7 @@ describe('EmployeeNotAvailableDirective', () => {
 
     const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
     fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
 
     expect(mockEmployeeService.getEmployee).toHaveBeenCalledWith(1);
@@ -70,6 +71,7 @@ describe('EmployeeNotAvailableDirective', () => {
 
     const fixture: ComponentFixture<HostComponent> = TestBed.createComponent(HostComponent);
     fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
 
     const link: HTMLAnchorElement = fixture.nativeElement.querySelector('a');

--- a/src/app/shared/directives/loader.directive.spec.ts
+++ b/src/app/shared/directives/loader.directive.spec.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { LoaderDirective } from './loader.directive';
+import { LoaderComponent } from '../components/loader.component';
+
+@Component({
+  standalone: true,
+  imports: [LoaderDirective],
+  template: `<div *loading="isLoading">Content</div>`,
+})
+class HostComponent {
+  isLoading = false;
+}
+
+describe('LoaderDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('should render an app-loader component wrapping the template content', () => {
+    fixture.detectChanges();
+    const loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
+    expect(loaderComponent).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('Content');
+  });
+
+  it('should pass the loading input through to the loader component', () => {
+    fixture.componentInstance.isLoading = true;
+    fixture.detectChanges();
+    const loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
+    expect(loaderComponent.componentInstance.loading).toBeTrue();
+  });
+
+  it('should update the loader component when the loading input changes', () => {
+    fixture.detectChanges();
+    let loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
+    expect(loaderComponent.componentInstance.loading).toBeFalse();
+
+    fixture.componentInstance.isLoading = true;
+    fixture.detectChanges();
+    loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
+    expect(loaderComponent.componentInstance.loading).toBeTrue();
+  });
+
+  it('should show the blocker element only while loading', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.blocker')).toBeFalsy();
+
+    fixture.componentInstance.isLoading = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.blocker')).toBeTruthy();
+  });
+});

--- a/src/app/shared/directives/loader.directive.spec.ts
+++ b/src/app/shared/directives/loader.directive.spec.ts
@@ -45,6 +45,7 @@ describe('LoaderDirective', () => {
 
     fixture.componentInstance.isLoading = true;
     fixture.detectChanges();
+    fixture.detectChanges();
     loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
     expect(loaderComponent.componentInstance.loading).toBeTrue();
   });
@@ -54,6 +55,7 @@ describe('LoaderDirective', () => {
     expect(fixture.nativeElement.querySelector('.blocker')).toBeFalsy();
 
     fixture.componentInstance.isLoading = true;
+    fixture.detectChanges();
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.blocker')).toBeTruthy();
   });

--- a/src/app/shared/directives/loader.directive.spec.ts
+++ b/src/app/shared/directives/loader.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { LoaderDirective } from './loader.directive';
 import { LoaderComponent } from '../components/loader.component';
+import { flushChanges } from 'src/testing/flush-changes';
 
 @Component({
   standalone: true,
@@ -33,7 +34,7 @@ describe('LoaderDirective', () => {
 
   it('should pass the loading input through to the loader component', () => {
     fixture.componentInstance.isLoading = true;
-    fixture.detectChanges();
+    flushChanges(fixture);
     const loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
     expect(loaderComponent.componentInstance.loading).toBeTrue();
   });
@@ -44,8 +45,7 @@ describe('LoaderDirective', () => {
     expect(loaderComponent.componentInstance.loading).toBeFalse();
 
     fixture.componentInstance.isLoading = true;
-    fixture.detectChanges();
-    fixture.detectChanges();
+    flushChanges(fixture);
     loaderComponent = fixture.debugElement.query(By.directive(LoaderComponent));
     expect(loaderComponent.componentInstance.loading).toBeTrue();
   });
@@ -55,8 +55,7 @@ describe('LoaderDirective', () => {
     expect(fixture.nativeElement.querySelector('.blocker')).toBeFalsy();
 
     fixture.componentInstance.isLoading = true;
-    fixture.detectChanges();
-    fixture.detectChanges();
+    flushChanges(fixture);
     expect(fixture.nativeElement.querySelector('.blocker')).toBeTruthy();
   });
 });

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TooltipDirective } from './tooltip.directive';
+
+@Component({
+  standalone: true,
+  imports: [TooltipDirective],
+  template: `<appTooltip [tooltip]="tooltipText"></appTooltip>`,
+})
+class HostComponent {
+  tooltipText = 'Hello world';
+}
+
+describe('TooltipDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  it('should create an instance', () => {
+    fixture.detectChanges();
+    const directiveEl = fixture.debugElement.children[0];
+    expect(directiveEl.injector.get(TooltipDirective)).toBeTruthy();
+  });
+
+  it('should bind the tooltip input to the title attribute', () => {
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
+    expect(el.getAttribute('title')).toBe('Hello world');
+  });
+
+  it('should update the title attribute when the tooltip input changes', () => {
+    fixture.detectChanges();
+    fixture.componentInstance.tooltipText = 'Updated tooltip';
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
+    expect(el.getAttribute('title')).toBe('Updated tooltip');
+  });
+});

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -31,7 +31,7 @@ describe('TooltipDirective', () => {
   it('should bind the tooltip input to the title attribute', () => {
     fixture.detectChanges();
     const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
-    expect(el.getAttribute('title')).toBe('Hello world');
+    expect(el.title).toBe('Hello world');
   });
 
   it('should update the title attribute when the tooltip input changes', () => {
@@ -39,6 +39,6 @@ describe('TooltipDirective', () => {
     fixture.componentInstance.tooltipText = 'Updated tooltip';
     fixture.detectChanges();
     const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
-    expect(el.getAttribute('title')).toBe('Updated tooltip');
+    expect(el.title).toBe('Updated tooltip');
   });
 });

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TooltipDirective } from './tooltip.directive';
+import { flushChanges } from 'src/testing/flush-changes';
 
 @Component({
   standalone: true,
@@ -31,14 +32,14 @@ describe('TooltipDirective', () => {
   it('should bind the tooltip input to the title attribute', () => {
     fixture.detectChanges();
     const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
-    expect(el.title).toBe('Hello world');
+    expect(el.getAttribute('title')).toBe('Hello world');
   });
 
   it('should update the title attribute when the tooltip input changes', () => {
     fixture.detectChanges();
     fixture.componentInstance.tooltipText = 'Updated tooltip';
-    fixture.detectChanges();
+    flushChanges(fixture);
     const el: HTMLElement = fixture.nativeElement.querySelector('appTooltip');
-    expect(el.title).toBe('Updated tooltip');
+    expect(el.getAttribute('title')).toBe('Updated tooltip');
   });
 });

--- a/src/app/shared/directives/truncate.directive.spec.ts
+++ b/src/app/shared/directives/truncate.directive.spec.ts
@@ -1,0 +1,76 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TruncateDirective, TruncateLimit } from './truncate.directive';
+
+const LONG_TEXT = 'a'.repeat(200);
+
+@Component({
+  standalone: true,
+  imports: [TruncateDirective],
+  template: `<p appTruncate>{{ text }}</p>`,
+})
+class HostComponent {
+  text = LONG_TEXT;
+}
+
+describe('TruncateDirective', () => {
+  describe('with the app TruncateLimit provided (70)', () => {
+    let fixture: ComponentFixture<HostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostComponent],
+        providers: [{ provide: TruncateLimit, useValue: 70 }],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(HostComponent);
+    });
+
+    it('should truncate the text content to the provided limit', () => {
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement.querySelector('p');
+      expect(el.textContent).toBe(LONG_TEXT.slice(0, 70));
+      expect(el.textContent?.length).toBe(70);
+    });
+  });
+
+  describe('without TruncateLimit provided', () => {
+    let fixture: ComponentFixture<HostComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostComponent],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(HostComponent);
+    });
+
+    it('should default the limit to 80 characters', () => {
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement.querySelector('p');
+      expect(el.textContent).toBe(LONG_TEXT.slice(0, 80));
+      expect(el.textContent?.length).toBe(80);
+    });
+  });
+
+  describe('with short text', () => {
+    @Component({
+      standalone: true,
+      imports: [TruncateDirective],
+      template: `<p appTruncate>Short text</p>`,
+    })
+    class ShortTextHostComponent {}
+
+    it('should leave text shorter than the limit untouched', async () => {
+      await TestBed.configureTestingModule({
+        imports: [ShortTextHostComponent],
+        providers: [{ provide: TruncateLimit, useValue: 70 }],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(ShortTextHostComponent);
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement.querySelector('p');
+      expect(el.textContent).toBe('Short text');
+    });
+  });
+});

--- a/src/app/shared/functions/create-search.spec.ts
+++ b/src/app/shared/functions/create-search.spec.ts
@@ -1,0 +1,101 @@
+import { DestroyRef } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormControl } from '@angular/forms';
+import { createSearch } from './create-search';
+
+describe('createSearch', () => {
+  let onDestroyCallback: () => void;
+
+  const mockDestroyRef: Partial<DestroyRef> = {
+    onDestroy: (callback: () => void) => {
+      onDestroyCallback = callback;
+      return () => {};
+    },
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should not emit before the debounce time elapses', fakeAsync(() => {
+    const control = new FormControl('');
+    const values: (string | null)[] = [];
+
+    TestBed.runInInjectionContext(() => {
+      createSearch(control, mockDestroyRef as DestroyRef).subscribe((value) => values.push(value));
+    });
+
+    control.setValue('a');
+    tick(499);
+
+    expect(values).toEqual([]);
+    tick(1);
+  }));
+
+  it('should emit the debounced value after 500ms', fakeAsync(() => {
+    const control = new FormControl('');
+    const values: (string | null)[] = [];
+
+    TestBed.runInInjectionContext(() => {
+      createSearch(control, mockDestroyRef as DestroyRef).subscribe((value) => values.push(value));
+    });
+
+    control.setValue('john');
+    tick(500);
+
+    expect(values).toEqual(['john']);
+  }));
+
+  it('should only emit the latest value when multiple changes happen within the debounce window', fakeAsync(() => {
+    const control = new FormControl('');
+    const values: (string | null)[] = [];
+
+    TestBed.runInInjectionContext(() => {
+      createSearch(control, mockDestroyRef as DestroyRef).subscribe((value) => values.push(value));
+    });
+
+    control.setValue('j');
+    tick(100);
+    control.setValue('jo');
+    tick(100);
+    control.setValue('john');
+    tick(500);
+
+    expect(values).toEqual(['john']);
+  }));
+
+  it('should stop emitting once destroyRef fires onDestroy', fakeAsync(() => {
+    const control = new FormControl('');
+    const values: (string | null)[] = [];
+    let completed = false;
+
+    TestBed.runInInjectionContext(() => {
+      createSearch(control, mockDestroyRef as DestroyRef).subscribe({
+        next: (value) => values.push(value),
+        complete: () => (completed = true),
+      });
+    });
+
+    onDestroyCallback();
+
+    control.setValue('after-destroy');
+    tick(500);
+
+    expect(values).toEqual([]);
+    expect(completed).toBeTrue();
+  }));
+
+  it('should use the real DestroyRef when none is provided explicitly', fakeAsync(() => {
+    const control = new FormControl('');
+    const values: (string | null)[] = [];
+
+    TestBed.runInInjectionContext(() => {
+      createSearch(control).subscribe((value) => values.push(value));
+    });
+
+    control.setValue('default');
+    tick(500);
+
+    expect(values).toEqual(['default']);
+  }));
+});

--- a/src/app/shared/functions/is-auth.spec.ts
+++ b/src/app/shared/functions/is-auth.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { AuthService } from '../../services/auth.service';
+import { isAuth } from './is-auth';
+
+describe('isAuth', () => {
+  let isAuth$: BehaviorSubject<boolean>;
+
+  beforeEach(() => {
+    isAuth$ = new BehaviorSubject(false);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AuthService,
+          useValue: { isAuth$ },
+        },
+      ],
+    });
+  });
+
+  it('should emit the current authentication state', (done) => {
+    TestBed.runInInjectionContext(() => {
+      isAuth().subscribe((value) => {
+        expect(value).toBeFalse();
+        done();
+      });
+    });
+  });
+
+  it('should emit updated values when the underlying subject changes', () => {
+    const values: boolean[] = [];
+
+    TestBed.runInInjectionContext(() => {
+      isAuth().subscribe((value) => values.push(value));
+    });
+
+    isAuth$.next(true);
+
+    expect(values).toEqual([false, true]);
+  });
+
+  it('should return an Observable, not the subject itself', () => {
+    let result: unknown;
+
+    TestBed.runInInjectionContext(() => {
+      result = isAuth();
+    });
+
+    expect(result).not.toBe(isAuth$);
+    expect((result as { next?: unknown }).next).toBeUndefined();
+  });
+});

--- a/src/app/shared/guards/auth.guard.spec.ts
+++ b/src/app/shared/guards/auth.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { AuthService } from 'src/app/services/auth.service';
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  let mockAuthService: { isAuth$: Observable<boolean> };
+  let mockRouter: { createUrlTree: jasmine.Spy };
+  let mockUrlTree: UrlTree;
+
+  const runGuard = () =>
+    TestBed.runInInjectionContext(() => authGuard(null as any, null as any));
+
+  beforeEach(() => {
+    mockUrlTree = {} as UrlTree;
+    mockRouter = {
+      createUrlTree: jasmine.createSpy('createUrlTree').and.returnValue(mockUrlTree),
+    };
+
+    mockAuthService = { isAuth$: of(true) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: mockRouter },
+        { provide: AuthService, useValue: mockAuthService },
+      ],
+    });
+  });
+
+  it('should allow activation when the user is authenticated', (done) => {
+    mockAuthService.isAuth$ = of(true);
+
+    const result = runGuard();
+    (result as Observable<boolean>).subscribe((value) => {
+      expect(value).toBeTrue();
+      expect(mockRouter.createUrlTree).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should redirect to /login when the user is not authenticated', (done) => {
+    mockAuthService.isAuth$ = of(false);
+
+    const result = runGuard();
+    (result as Observable<boolean | UrlTree>).subscribe((value) => {
+      expect(value).toBe(mockUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/login']);
+      done();
+    });
+  });
+});

--- a/src/app/shared/interceptors/api-url.interceptor.spec.ts
+++ b/src/app/shared/interceptors/api-url.interceptor.spec.ts
@@ -1,0 +1,44 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from 'src/environments/environment';
+import { addApiUrl } from './api-url.interceptor';
+
+describe('addApiUrl', () => {
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([addApiUrl])),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should prefix relative request URLs with the environment apiUrl', () => {
+    httpClient.get('/employees').subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/employees`);
+    expect(req.request.url).toBe(`${environment.apiUrl}/employees`);
+    req.flush({});
+  });
+
+  it('should preserve the original request method and body', () => {
+    const body = { firstName: 'John' };
+    httpClient.post('/employees', body).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/employees`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({});
+  });
+});

--- a/src/app/shared/interceptors/auth.interceptor.spec.ts
+++ b/src/app/shared/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,61 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from 'src/app/services/auth.service';
+import { environment } from 'src/environments/environment';
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  let mockAuthService: { getToken: jasmine.Spy };
+
+  beforeEach(() => {
+    mockAuthService = { getToken: jasmine.createSpy('getToken').and.returnValue(null) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: mockAuthService },
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should attach an Authorization header when a token is present and the URL targets our API', () => {
+    mockAuthService.getToken.and.returnValue('abc123');
+
+    httpClient.get(`${environment.apiUrl}/employees`).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/employees`);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer abc123');
+    req.flush({});
+  });
+
+  it('should not attach an Authorization header when there is no token', () => {
+    mockAuthService.getToken.and.returnValue(null);
+
+    httpClient.get(`${environment.apiUrl}/employees`).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/employees`);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+
+  it('should not attach an Authorization header for requests not bound for our API', () => {
+    mockAuthService.getToken.and.returnValue('abc123');
+
+    httpClient.get('https://external.example.com/data').subscribe();
+
+    const req = httpMock.expectOne('https://external.example.com/data');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({});
+  });
+});

--- a/src/app/shared/interceptors/employee-permissions.interceptor.spec.ts
+++ b/src/app/shared/interceptors/employee-permissions.interceptor.spec.ts
@@ -1,0 +1,70 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PermissionsService } from 'src/app/services/permissions.service';
+import { employeePermissionsInterceptor } from './employee-permissions.interceptor';
+
+describe('employeePermissionsInterceptor', () => {
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  let mockPermissionsService: { hasPermissions: jasmine.Spy };
+
+  beforeEach(() => {
+    mockPermissionsService = { hasPermissions: jasmine.createSpy('hasPermissions').and.returnValue(of(true)) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([employeePermissionsInterceptor])),
+        provideHttpClientTesting(),
+        { provide: PermissionsService, useValue: mockPermissionsService },
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should let responses through for /employees requests when permissions are granted', () => {
+    let response: unknown;
+    httpClient.get('/employees').subscribe((res) => (response = res));
+
+    const req = httpMock.expectOne('/employees');
+    req.flush([{ id: 1 }]);
+
+    expect(response).toEqual([{ id: 1 }]);
+    expect(mockPermissionsService.hasPermissions).toHaveBeenCalledWith([
+      'CreateEmployee',
+      'DeleteEmployee',
+      'EditEmployeeGeneralDetails',
+      'ViewEmployees',
+    ]);
+  });
+
+  it('should filter out the response for /employees requests when permissions are not granted', () => {
+    mockPermissionsService.hasPermissions.and.returnValue(of(false));
+
+    let emitted = false;
+    httpClient.get('/employees').subscribe(() => (emitted = true));
+
+    const req = httpMock.expectOne('/employees');
+    req.flush([{ id: 1 }]);
+
+    expect(emitted).toBeFalse();
+  });
+
+  it('should bypass permission checks entirely for non /employees requests', () => {
+    let response: unknown;
+    httpClient.get('/candidates').subscribe((res) => (response = res));
+
+    const req = httpMock.expectOne('/candidates');
+    req.flush([{ id: 2 }]);
+
+    expect(response).toEqual([{ id: 2 }]);
+    expect(mockPermissionsService.hasPermissions).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/operators/has-permissions.operator.spec.ts
+++ b/src/app/shared/operators/has-permissions.operator.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
+import { PermissionsService } from 'src/app/services/permissions.service';
+import { hasPermissions } from './has-permissions.operator';
+
+describe('hasPermissions', () => {
+  it('should let the source value through when hasPermissions resolves to true', () => {
+    const mockPermissionsService = {
+      hasPermissions: () => of(true),
+    };
+
+    const values: string[] = [];
+    of('value').pipe(hasPermissions(['ViewEmployees'], mockPermissionsService as unknown as PermissionsService))
+      .subscribe((value) => values.push(value));
+
+    expect(values).toEqual(['value']);
+  });
+
+  it('should filter out the source value when hasPermissions resolves to false', () => {
+    const mockPermissionsService = {
+      hasPermissions: () => of(false),
+    };
+
+    const values: string[] = [];
+    of('value').pipe(hasPermissions(['ViewEmployees'], mockPermissionsService as unknown as PermissionsService))
+      .subscribe((value) => values.push(value));
+
+    expect(values).toEqual([]);
+  });
+
+  it('should re-evaluate against the latest permissions value when the source emits', () => {
+    const permissions$ = new BehaviorSubject(false);
+    const mockPermissionsService = {
+      hasPermissions: () => permissions$.asObservable(),
+    };
+
+    const values: number[] = [];
+    const source$ = new BehaviorSubject(1);
+
+    source$.pipe(hasPermissions(['CreateEmployee'], mockPermissionsService as unknown as PermissionsService))
+      .subscribe((value) => values.push(value));
+
+    expect(values).toEqual([]);
+
+    permissions$.next(true);
+    source$.next(2);
+
+    expect(values).toEqual([2]);
+  });
+
+  it('should use the injected PermissionsService when none is provided explicitly', () => {
+    const mockPermissionsService = {
+      hasPermissions: () => of(true),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: PermissionsService, useValue: mockPermissionsService }],
+    });
+
+    const values: string[] = [];
+    TestBed.runInInjectionContext(() => {
+      of('value').pipe(hasPermissions(['ViewEmployees'])).subscribe((value) => values.push(value));
+    });
+
+    expect(values).toEqual(['value']);
+  });
+});

--- a/src/app/shared/resolvers/candidate-details.resolver.spec.ts
+++ b/src/app/shared/resolvers/candidate-details.resolver.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { Candidate } from 'src/app/infrastructure/types/candidate';
+import { CandidateService } from 'src/app/services/candidate.service';
+import { candidateDetailsResolver } from './candidate-details.resolver';
+
+describe('candidateDetailsResolver', () => {
+  let mockCandidateService: { getCandidate: jasmine.Spy };
+
+  const mockCandidate: Candidate = {
+    id: 5,
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane.doe@example.com',
+    position: 'Developer',
+    level: 'Senior',
+    status: 'Interviewing',
+    offerAccepted: false,
+  };
+
+  const buildSnapshot = (id: string | null): ActivatedRouteSnapshot =>
+    ({ paramMap: { get: () => id } } as unknown as ActivatedRouteSnapshot);
+
+  beforeEach(() => {
+    mockCandidateService = { getCandidate: jasmine.createSpy('getCandidate').and.returnValue(of(mockCandidate)) };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: CandidateService, useValue: mockCandidateService }],
+    });
+  });
+
+  it('should call CandidateService.getCandidate with the numeric id from the route', (done) => {
+    TestBed.runInInjectionContext(() => {
+      const result = candidateDetailsResolver(buildSnapshot('5'), null as any);
+      (result as Observable<Candidate>).subscribe((candidate) => {
+        expect(mockCandidateService.getCandidate).toHaveBeenCalledWith(5);
+        expect(candidate).toEqual(mockCandidate);
+        done();
+      });
+    });
+  });
+
+  it('should default to id 0 when the route has no id param', () => {
+    TestBed.runInInjectionContext(() => {
+      candidateDetailsResolver(buildSnapshot(null), null as any);
+    });
+
+    expect(mockCandidateService.getCandidate).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/app/shared/resolvers/employee-details.resolver.spec.ts
+++ b/src/app/shared/resolvers/employee-details.resolver.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { Employee } from 'src/app/infrastructure/types/employee';
+import { EmployeeService } from 'src/app/services/employee.service';
+import { employeeDetailsResolver } from './employee-details.resolver';
+
+describe('employeeDetailsResolver', () => {
+  let mockEmployeeService: { getEmployee: jasmine.Spy };
+
+  const mockEmployee: Employee = {
+    id: 7,
+    firstName: 'John',
+    lastName: 'Smith',
+    email: 'john.smith@example.com',
+    position: 'Developer',
+    level: 'Senior',
+    isAvailable: true,
+    profilePicture: '',
+  };
+
+  const buildSnapshot = (id: string | null): ActivatedRouteSnapshot =>
+    ({ paramMap: { get: () => id } } as unknown as ActivatedRouteSnapshot);
+
+  beforeEach(() => {
+    mockEmployeeService = { getEmployee: jasmine.createSpy('getEmployee').and.returnValue(of(mockEmployee)) };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: EmployeeService, useValue: mockEmployeeService }],
+    });
+  });
+
+  it('should call EmployeeService.getEmployee with the numeric id from the route', (done) => {
+    TestBed.runInInjectionContext(() => {
+      const result = employeeDetailsResolver(buildSnapshot('7'), null as any);
+      (result as Observable<Employee>).subscribe((employee) => {
+        expect(mockEmployeeService.getEmployee).toHaveBeenCalledWith(7);
+        expect(employee).toEqual(mockEmployee);
+        done();
+      });
+    });
+  });
+
+  it('should default to id 0 when the route has no id param', () => {
+    TestBed.runInInjectionContext(() => {
+      employeeDetailsResolver(buildSnapshot(null), null as any);
+    });
+
+    expect(mockEmployeeService.getEmployee).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/testing/flush-changes.ts
+++ b/src/testing/flush-changes.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+
+/**
+ * Runs change detection after a plain (non-signal) property has been mutated.
+ *
+ * TestBed runs zoneless, so `fixture.detectChanges()` only refreshes views that
+ * are already marked dirty, and mutating a plain property never marks one. The
+ * view has to be marked via its own `ChangeDetectorRef` — the one on
+ * `fixture.componentRef` belongs to the host view and does not have this effect.
+ */
+export function flushChanges(fixture: ComponentFixture<unknown>): void {
+  fixture.debugElement.injector.get(ChangeDetectorRef).markForCheck();
+  fixture.detectChanges();
+}


### PR DESCRIPTION
## Summary
The codebase had only 2 spec files across 62 non-spec `.ts` source files (`app.component.spec.ts` and `edit-employee.component.spec.ts`). This adds co-located Jasmine spec files for every service, standalone component, directive, guard, interceptor, resolver, and shared pure function that lacked one — 45 new spec files, 47 total.

Coverage added for:
- **Services** (9): auth, candidate, employee, notification, permissions, project, socket, time-off-management, time-off-request
- **Directives** (4): employee-not-available, loader, tooltip, truncate
- **Guards/interceptors/resolvers/operators** (7): auth guard, api-url/auth/employee-permissions interceptors, candidate-details/employee-details resolvers, has-permissions operator
- **Pure functions** (2): create-search, is-auth
- **Shared components** (6): confirmation-dialog, file-upload, footer, header, loader, project-card
- **Pages** (17): employees (create/details/list), login, registration, recruitment (candidate-details, candidates-list, + 6 sub-components), work (project-details, project-list, time-off-management), app.config's `imageLoader`

All specs follow the existing house style from `edit-employee.component.spec.ts`/`app.component.spec.ts`: standalone `TestBed.configureTestingModule`, `provideHttpClientTesting()`/`HttpTestingController` for HTTP-backed services (verified with `httpMock.verify()`), and plain `useValue` mocks for dependencies.

Also adds `istanbul-lib-instrument` as a dev dependency — it's required by `ng test --code-coverage` but was missing, so coverage reports couldn't be generated at all.

## Notes for reviewer
- I could not execute the Karma/Chrome test runner in my sandbox (ARM64 host; Puppeteer only ships x86_64 Linux Chrome, no emulation available) — validated instead via `npx tsc -p tsconfig.spec.json --noEmit` (clean) plus manual review. Found and fixed one real bug this way: `notification.service.spec.ts` was calling `service.connect()` (which internally uses `takeUntilDestroyed()`) outside an Angular injection context, which throws `NG0203` — fixed by wrapping in `TestBed.runInInjectionContext(...)`.
- CI runs on a real x86_64 runner where Chrome launches fine, so it's the actual verification for this PR — please check the Build & Test job results before merging. If anything fails there I'll iterate.

## Test plan
- [x] `npx tsc -p tsconfig.spec.json --noEmit` — compiles clean
- [x] `npm run build` — succeeds
- [ ] `npm test` (Karma/ChromeHeadless) — could not run locally; verify via CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)