### PR TITLE
deps: bump codeql-action and @angular/build+cli past cooloff

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@angular/build": "22.1.0",
-        "@angular/cli": "22.1.0",
+        "@angular/build": "22.1.2",
+        "@angular/cli": "22.1.2",
         "@angular/compiler-cli": "22.1.0",
         "@types/jasmine": "6.0.0",
         "istanbul-lib-instrument": "6.0.3",
@@ -51,13 +51,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.0.tgz",
-      "integrity": "sha512-5/AOHK/9K5vNJngDCKuja223fNVxQUx4kneGBHr5vsh78Tj1iueCxMy3BnTawsZ54djxW+Qy74Q9zzvdYqm/YQ==",
+      "version": "0.2201.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.2.tgz",
+      "integrity": "sha512-RRG3JA3hPH0ypbDIyquZt9DDTP5pOMPgqQ/iLSkok1MZdKiOgpk6FGfXCa1ei72SwlX7lnJdq94d6WWdqpbyKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.0",
+        "@angular-devkit/core": "22.1.2",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.0.tgz",
-      "integrity": "sha512-FUwmS33Yc97FCOEpFlA2L8KISrxMRggBLUzfFkrXcxMtvPs/zTjbKtf/9ElZQyW0+a6TzAj/tyZUf0/FsM3bZg==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.2.tgz",
+      "integrity": "sha512-tF1oEE7KPs8I08HJQmH5e4GkLUB3+MXXy8t6gMJULaLFxZYP9K1oXRFLappMpdm9OIbEXOChk23hrho0By9aYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -98,13 +98,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.0.tgz",
-      "integrity": "sha512-HDF9DvBR7l5tu5Tzkuo7Z4glldV4VsWP61qlbXYgwPcTlVluew6k9P3hUNHSwNozG6nGxLnAcenI3wDsQu2cMQ==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.2.tgz",
+      "integrity": "sha512-Lw6NvW5rfMUl/2dsuWY8l6wlfWCuYBzCYSSqqliLPDco0doGzBliHwY9uxuzuUKZgOl5TvuVyvEo0t3o4Jj4GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.0",
+        "@angular-devkit/core": "22.1.2",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.0.tgz",
-      "integrity": "sha512-1AyhEOV+Yc0tB5a0DA0k16H4eO3FHVi1vrIX83Y/C46u0AIedg82zVwi+8jMwOJR/k2FcRnMhAvhDX5ffCTV1A==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.2.tgz",
+      "integrity": "sha512-DE/3o17JTel4EBt2BA4DqJYeBBuz5Ef/kf1jL9YZTyJu4SrLr/HI79K14jFr0VRIxzcqG92FdIzfLDxbOesQsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.0",
+        "@angular-devkit/architect": "0.2201.2",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -154,7 +154,7 @@
         "listr2": "10.2.2",
         "magic-string": "1.0.0",
         "mrmime": "2.0.1",
-        "oxc-parser": "0.140.0",
+        "oxc-parser": "0.142.0",
         "parse5-html-rewriting-stream": "8.0.1",
         "picomatch": "4.0.5",
         "piscina": "5.2.0",
@@ -182,7 +182,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.0",
+        "@angular/ssr": "^22.1.2",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -497,19 +497,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.0.tgz",
-      "integrity": "sha512-0Nf5UNFzF/Uwdc+nylpLNoe7RrRo7VUCYxzC/gixgd+j3Rr0ybZwKL4M6H+blHilSDF5lM6muw8k6CNshQIDfQ==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.2.tgz",
+      "integrity": "sha512-gzB+iuZzB507DAkZb9s5+Jw8QRzOBolUhHEuAKH74xF6oWlEP5JdexfTgti45SjXaKKqeYpODJFnUmSQQJRhxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.0",
-        "@angular-devkit/core": "22.1.0",
-        "@angular-devkit/schematics": "22.1.0",
+        "@angular-devkit/architect": "0.2201.2",
+        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/schematics": "22.1.2",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.4",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.1.0",
+        "@schematics/angular": "22.1.2",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.2",
         "npm-package-arg": "14.0.0",
@@ -2794,9 +2794,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
-      "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.142.0.tgz",
+      "integrity": "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==",
       "cpu": [
         "arm"
       ],
@@ -2811,9 +2811,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
-      "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.142.0.tgz",
+      "integrity": "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==",
       "cpu": [
         "arm64"
       ],
@@ -2828,9 +2828,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
-      "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.142.0.tgz",
+      "integrity": "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==",
       "cpu": [
         "arm64"
       ],
@@ -2845,9 +2845,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
-      "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.142.0.tgz",
+      "integrity": "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==",
       "cpu": [
         "x64"
       ],
@@ -2862,9 +2862,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
-      "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.142.0.tgz",
+      "integrity": "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==",
       "cpu": [
         "x64"
       ],
@@ -2879,9 +2879,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
-      "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.142.0.tgz",
+      "integrity": "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==",
       "cpu": [
         "arm"
       ],
@@ -2896,9 +2896,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
-      "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.142.0.tgz",
+      "integrity": "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==",
       "cpu": [
         "arm"
       ],
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
-      "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.142.0.tgz",
+      "integrity": "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==",
       "cpu": [
         "arm64"
       ],
@@ -2933,9 +2933,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
-      "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.142.0.tgz",
+      "integrity": "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==",
       "cpu": [
         "arm64"
       ],
@@ -2953,9 +2953,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
-      "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.142.0.tgz",
+      "integrity": "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==",
       "cpu": [
         "ppc64"
       ],
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
-      "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.142.0.tgz",
+      "integrity": "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==",
       "cpu": [
         "riscv64"
       ],
@@ -2993,9 +2993,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
-      "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.142.0.tgz",
+      "integrity": "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==",
       "cpu": [
         "riscv64"
       ],
@@ -3013,9 +3013,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
-      "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.142.0.tgz",
+      "integrity": "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==",
       "cpu": [
         "s390x"
       ],
@@ -3033,9 +3033,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
-      "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.142.0.tgz",
+      "integrity": "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==",
       "cpu": [
         "x64"
       ],
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
-      "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.142.0.tgz",
+      "integrity": "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==",
       "cpu": [
         "x64"
       ],
@@ -3073,9 +3073,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
-      "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.142.0.tgz",
+      "integrity": "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==",
       "cpu": [
         "arm64"
       ],
@@ -3090,9 +3090,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
-      "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.142.0.tgz",
+      "integrity": "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==",
       "cpu": [
         "wasm32"
       ],
@@ -3109,9 +3109,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
-      "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.142.0.tgz",
+      "integrity": "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==",
       "cpu": [
         "arm64"
       ],
@@ -3126,9 +3126,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
-      "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.142.0.tgz",
+      "integrity": "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==",
       "cpu": [
         "ia32"
       ],
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
-      "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.142.0.tgz",
+      "integrity": "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==",
       "cpu": [
         "x64"
       ],
@@ -3817,14 +3817,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.0.tgz",
-      "integrity": "sha512-3nI/qZ75RPadJ0R0YMe6zKZPHYYJXw4U6Ha+HToostCFlIRh52qC+zH0j/pghgyggwMkvRsE9qekKkRUHqPIbw==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.2.tgz",
+      "integrity": "sha512-52udja/QGSNH5geSnL4JWFOEfx8M7tqf7LNXz8byjki4VshVOkKHTawQcL4YbJfo3MfwwXm4AsoadMOk8EST2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.0",
-        "@angular-devkit/schematics": "22.1.0",
+        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/schematics": "22.1.2",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -7467,13 +7467,13 @@
       "optional": true
     },
     "node_modules/oxc-parser": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
-      "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.142.0.tgz",
+      "integrity": "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.140.0"
+        "@oxc-project/types": "^0.142.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -7482,26 +7482,36 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.140.0",
-        "@oxc-parser/binding-android-arm64": "0.140.0",
-        "@oxc-parser/binding-darwin-arm64": "0.140.0",
-        "@oxc-parser/binding-darwin-x64": "0.140.0",
-        "@oxc-parser/binding-freebsd-x64": "0.140.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.140.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.140.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.140.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.142.0",
+        "@oxc-parser/binding-android-arm64": "0.142.0",
+        "@oxc-parser/binding-darwin-arm64": "0.142.0",
+        "@oxc-parser/binding-darwin-x64": "0.142.0",
+        "@oxc-parser/binding-freebsd-x64": "0.142.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.142.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.142.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.142.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.142.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.142.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.142.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.142.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.142.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.142.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.142.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.142.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/parse5": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
-    "@angular/build": "22.1.0",
-    "@angular/cli": "22.1.0",
+    "@angular/build": "22.1.2",
+    "@angular/cli": "22.1.2",
     "@angular/compiler-cli": "22.1.0",
     "@types/jasmine": "6.0.0",
     "istanbul-lib-instrument": "6.0.3",


### PR DESCRIPTION
## Summary
- `github/codeql-action` (init, analyze) → v4.37.4, SHA-pinned.
- `@angular/build` and `@angular/cli` → 22.1.2, plus a transitive `oxc-parser` bump (0.140.0 → 0.142.0, individually cooloff-checked).
- Everything else (`@angular/core`, `rxjs`, `zone.js`, karma stack, etc.) was already at the newest cooloff-cleared version.

## Held back by cooloff (revisit 2026-08-04)
- `github/codeql-action` v4.37.5 — ~21h short.
- `oxc-parser` 0.143.0 — ~24h short.

## Not included — major version bump
`typescript` 6.0.3 → 7.0.2 clears cooloff but is a ground-up rewrite; compatibility with Angular 22's toolchain is unconfirmed. Recommend reviewing separately.

## Flagged, not fixed by this PR
`npm audit` reports 12 pre-existing vulnerabilities (6 high, 4 moderate, 2 low) in the dependency tree, unrelated to this update. Worth a separate triage pass.

## Test plan
- [x] `npm ci` — succeeds, 488 packages
- [x] `npm run build` — succeeds
- [ ] `npm test` — could not run in this sandbox: cached Puppeteer Chrome binaries are x86-64 but the host is aarch64 (pre-existing environment limitation, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)