### PR TITLE
fix(deps): bump @hono/node-server 1.19.17 → 2.1.0 (GHSA-frvp-7c67-39w9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,13 +1771,13 @@
       "optional": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "overrides": {
     "puppeteer-core": {
       "ws": "8.21.2"
-    }
+    },
+    "@hono/node-server": "2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #147 (**medium**, `development` scope): path traversal in `@hono/node-server`'s serve-static middleware on Windows via an encoded backslash (`%5C`) — [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9). No CVE assigned yet.
- `@hono/node-server` 1.19.17 → **2.1.0** (advisory's floor is 2.0.5; 2.1.0 cleared the 24h cooloff — published 2026-08-04, ~128h old at resolution time, 97 versions considered).
- **Transitive, forced via `overrides`** (stopgap): `@hono/node-server` is pulled in by `@angular/cli@22.1.3` → `@modelcontextprotocol/sdk@1.29.0`, which pins `"@hono/node-server": "^1.19.9"`. No stable `@angular/cli` release exists yet that depends on an SDK version allowing the 2.x line (SDK 1.30.0 widens this to `^1.19.9 || ^2.0.5`, but no Angular CLI release consumes 1.30.0 yet). Bumping the direct dependency (`@angular/cli`) isn't possible without a prerelease, so this pins the transitive package directly via npm `overrides` as a documented stopgap.
- Checked the `@hono/node-server` v2.0.0 release notes: "the public API stays the same" — it's a performance-only major bump. Its only new requirement is Node `>=20`, already satisfied by this repo's runtime.
- `package-lock.json` diff is limited to this one package — no new or bumped sub-dependencies were dragged in, so no follow-up cooloff check was needed.

## Why this can be removed later
Once `@angular/cli` publishes a stable release depending on `@modelcontextprotocol/sdk` >=1.30.0, the `@hono/node-server` override in `package.json` can be dropped in favor of a normal transitive resolution.

## Test plan
- [x] `npm install` — lockfile regenerated cleanly, no `EOVERRIDE` conflicts
- [x] `npm run build` (`ng build`) — succeeds, bundle output unchanged in shape
- [ ] `npm test` — **not run**; this repo's karma test runner has a pre-existing, unrelated breakage (per repo owner), so `npm run build` was used as the verification signal instead
- [ ] Reviewer: confirm no code in this repo actually exercises `@hono/node-server`'s serve-static middleware at runtime (it's reached only through Angular CLI's MCP dev-server tooling, `development` scope) — worth a sanity check that `ng serve`/MCP tooling still behaves as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)