### PR TITLE
chore(deps): update 1 action (24h cooloff)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Updated `github/codeql-action` from v4.37.7 to v4.37.8 (SHA: db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28)

## Dependency Updates

| Package | Old | New | Age (hours) |
|---------|-----|-----|-------------|
| github/codeql-action | v4.37.7 | v4.37.8 | 72.53 |

## Held Back (Cooloff Window)

No dependencies held back.

## Skipped

- **typescript**: 6.0.3 → 7.0.2 - Major bump incompatible with Angular 22.1.3 (build fails)
- **jasmine-core**: 6.3.0 → 7.0.2 - Known broken (PR #67 zone.js/jasmine-core-7 incompatibility)
- **@angular/animations**, **@angular/platform-browser-dynamic**: Downgrade candidates (lock file artifacts)

## Verification

Build and CI workflow pass with updated action. No package.json changes (action-only update).

(Generated by dependabot-fixer agent)