### PR TITLE
Revert jasmine-core 7.0.1 bump (breaks test suite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@angular/compiler-cli": "22.1.3",
         "@types/jasmine": "6.0.0",
         "istanbul-lib-instrument": "6.0.3",
-        "jasmine-core": "7.0.1",
+        "jasmine-core": "6.3.0",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",
         "karma-coverage": "2.2.1",
@@ -6070,9 +6070,9 @@
       }
     },
     "node_modules/jasmine-core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-7.0.1.tgz",
-      "integrity": "sha512-AVUnCekV7RBFS6k4+bc9OrLTbEcDYM9gVHtUuPMWrpFUZBovr5p47WbVTKbr6gBYeAtBBe+nX32ivrvc0Ne2XA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@angular/compiler-cli": "22.1.3",
     "@types/jasmine": "6.0.0",
     "istanbul-lib-instrument": "6.0.3",
-    "jasmine-core": "7.0.1",
+    "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",
     "karma-coverage": "2.2.1",


### PR DESCRIPTION
## Summary
Reverts #67 (jasmine-core 6.3.0 -> 7.0.1). This bump broke the CI test suite: jasmine-core 7's stricter global handling conflicts with zone.js, producing \`Cannot assign to read only property 'describe'\` at test run time. Confirmed via master's post-merge CI: "Build & Test" is failing on the current tip (1cac583).

jasmine-core 7 support requires a zone.js/karma-jasmine compatibility update upstream first — not something to force through in a routine dependency bump.

## Test plan
- [x] `npm ci` succeeds
- [x] `npm run build` succeeds
- [ ] CI "Build & Test" should go green again once merged (cannot run karma/Chrome tests locally in this sandbox)