### PR TITLE
chore(deps): update 3 dependencies (24h cooloff)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@angular/build": "22.1.5",
-        "@angular/cli": "22.1.5",
+        "@angular/build": "22.1.6",
+        "@angular/cli": "22.1.6",
         "@angular/compiler-cli": "22.1.3",
         "@types/jasmine": "6.0.0",
         "istanbul-lib-instrument": "6.0.3",
@@ -32,7 +32,7 @@
         "karma-coverage": "2.2.1",
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.3.0",
-        "puppeteer": "25.8.0",
+        "puppeteer": "25.9.0",
         "typescript": "6.0.3"
       }
     },
@@ -51,13 +51,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.5.tgz",
-      "integrity": "sha512-DAticcJ2tw3M+D1CH4HhlCgMK5tAb0CwSsnczNMJB9QgQsBC/JhOozQTvgnyCvagitX9u+408YcwEW/Wo2pnzA==",
+      "version": "0.2201.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.6.tgz",
+      "integrity": "sha512-oGQEdof2/1bZk58PN9dvpGi8pvtbgE5vkP1xRtCqN8dSVxwre1l0pKynOj/Uge1KxjCvs4c1QrQu0vsAnY0vpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.5",
+        "@angular-devkit/core": "22.1.6",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.5.tgz",
-      "integrity": "sha512-HiY6d5dkIdJs5grP9OHvgkf14QOcDIo+hbuT7YKuLItQ++ZxCwUabJMLCCJ5R0KrstE5NqED0dNcyk5WD01t5Q==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.6.tgz",
+      "integrity": "sha512-KLBsZoc2RhOy0xSdeYcLoSOqV/fBP3feBmhY9o12ry2IuyW/17sCmWr6XbIfTIYQN6M98Y1ewmwVNFsvV5b0gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -98,13 +98,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.5.tgz",
-      "integrity": "sha512-HTmo9y8wjXKtJGVTYomTjZsjWzhirpu1pPRAzsVob3eiYOuxv1qDRAgWiHXNGp5CpnbHunZweXY/WffNGOFRyA==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.6.tgz",
+      "integrity": "sha512-IbDO9KbQyQm20uinsfT8d9ZtQw41/WVutI/65mAw39WZfN8Ky+MOgOUJCGLiSccMprvZ9YdodBTnN9bLH149Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.5",
+        "@angular-devkit/core": "22.1.6",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.5.tgz",
-      "integrity": "sha512-YqsbHZK3/HFmLLhwxa5SpN+3ABoVo5GFLV0fiEXCQg2KC7gw2pL15x692jxrq8gEGzT7O27bnjWkvFZ0bBHCnw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.6.tgz",
+      "integrity": "sha512-J7JBd3hDAV4dlGNMavDC0KjtvbDd4KOddaom1inwkq92tYnD1ljmhDDigAsUBnRvQhJ82cvagD8zi0s9Ki4rTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.5",
+        "@angular-devkit/architect": "0.2201.6",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -182,7 +182,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.5",
+        "@angular/ssr": "^22.1.6",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -240,19 +240,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.5.tgz",
-      "integrity": "sha512-YZkhI64INQHJkZ13h2n0/0PBrQ5ZZvFGiprrDiCOLAD0y1fehguL0PGp9HxF3ZWf+xWRyP//tIte2gmyAaiWLw==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.6.tgz",
+      "integrity": "sha512-HT3OzYkSpCyXMTgD5G1tsS7vkrY8cYJ/JgSjRjrpwOAooSMtKF1hv7BgBcn79sKg4eaiPLrDpQLXP93vHxgSFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.5",
-        "@angular-devkit/core": "22.1.5",
-        "@angular-devkit/schematics": "22.1.5",
+        "@angular-devkit/architect": "0.2201.6",
+        "@angular-devkit/core": "22.1.6",
+        "@angular-devkit/schematics": "22.1.6",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.5",
         "@modelcontextprotocol/sdk": "1.30.0",
-        "@schematics/angular": "22.1.5",
+        "@schematics/angular": "22.1.6",
         "jsonc-parser": "3.3.1",
         "listr2": "11.0.0",
         "npm-package-arg": "14.0.0",
@@ -3620,14 +3620,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.5.tgz",
-      "integrity": "sha512-3UXlO4YoGgQ6nEBbCTGRRHTfQuDcKgHbRaiivzSinHzOYigsskwvloMsa0LCBCO/3uJpDIjJIyTW0XKhDti0iA==",
+      "version": "22.1.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.6.tgz",
+      "integrity": "sha512-RiD4OZJ4yuaM1aXb3pt1gjDSWwkP0jrgiCuoaBls1eabcrDmlsNuQv0ekxbcGgCRPdSJvmHRZIHHmFPzei8w3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.5",
-        "@angular-devkit/schematics": "22.1.5",
+        "@angular-devkit/core": "22.1.6",
+        "@angular-devkit/schematics": "22.1.6",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -7994,9 +7994,9 @@
       "license": "MIT"
     },
     "node_modules/puppeteer": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
-      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.9.0.tgz",
+      "integrity": "sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8005,7 +8005,7 @@
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.8.0",
+        "puppeteer-core": "25.9.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
@@ -8016,9 +8016,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
-      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.9.0.tgz",
+      "integrity": "sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8027,7 +8027,7 @@
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
-    "@angular/build": "22.1.5",
-    "@angular/cli": "22.1.5",
+    "@angular/build": "22.1.6",
+    "@angular/cli": "22.1.6",
     "@angular/compiler-cli": "22.1.3",
     "@types/jasmine": "6.0.0",
     "istanbul-lib-instrument": "6.0.3",
@@ -34,7 +34,7 @@
     "karma-coverage": "2.2.1",
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.3.0",
-    "puppeteer": "25.8.0",
+    "puppeteer": "25.9.0",
     "typescript": "6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Updated 3 npm dependencies within the 24-hour supply-chain safety window.

## Updated Dependencies

| Package | Old | New | Published |
|---------|-----|-----|-----------|
| @angular/build | 22.1.5 | 22.1.6 | 27.96h ago |
| @angular/cli | 22.1.5 | 22.1.6 | 27.98h ago |
| puppeteer | 25.8.0 | 25.9.0 | 52.06h ago |

## Held Back by Cooloff

No dependencies held back; all applied updates are well past the 24h window.

## Known-Broken Packages Not Updated

**jasmine-core**: 7.0.2 is available (179h old, clears cooloff) but **NOT applied**. The 6→7 major bump was previously merged via Dependabot and had to be reverted due to zone.js incompatibility (cannot assign to read-only property 'describe'). Keeping at 6.3.0 as intended.

**TypeScript**: 7.0.2 available (1195h old) but **NOT applied**. Rejected due to peer dependency conflict: @angular/build@22.1.6 requires `typescript@">=6.0 <6.1"`. Staying at 6.0.3.

## Angular 22.1.x Patch Releases Held Back

@angular/compiler, @angular/core, @angular/forms, @angular/platform-browser, @angular/router, @angular/compiler-cli all have 22.1.4 available but held back at ~11.6h old (within 24h cooloff window).

## Test Plan

- [x] `npm ci` succeeded
- [x] `npm run build` passed
- [x] `npm test -- --watch=false --browsers=ChromeHeadless` passed (all specs passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)